### PR TITLE
Update API issue about large bill run errors

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -17,7 +17,7 @@ info:
     ### API
 
     - Query params are case senstive. Ensure they match what is in the spec below to avoid `422 - Unprocessable Entity` errors
-    - To generate a bill run summary you need to call the 'View Billrun' endpoint. The API currently appears to error doing this for ones with a large number of transactions (8-9K or more)
+    - To generate a bill run summary you need to call the 'View Billrun' endpoint. It is known bill runs with a large number of transactions (8-9K or more) and a lots of different customers can take a number of hours to complete
   version: "v0.3.0"
   title: Charging Module API
   contact:

--- a/openapi/versions/swagger_v0-3-0.yml
+++ b/openapi/versions/swagger_v0-3-0.yml
@@ -17,7 +17,7 @@ info:
     ### API
 
     - Query params are case senstive. Ensure they match what is in the spec below to avoid `422 - Unprocessable Entity` errors
-    - To generate a bill run summary you need to call the 'View Billrun' endpoint. The API currently appears to error doing this for ones with a large number of transactions (8-9K or more)
+    - To generate a bill run summary you need to call the 'View Billrun' endpoint. It is known bill runs with a large number of transactions (8-9K or more) and a lots of different customers can take a number of hours to complete
   version: v0.3.0
   title: Charging Module API
   contact:


### PR DESCRIPTION
We forgot to update the description about large bill runs causing an error in the API when we merged #18 . v0.3.0 of the API actually includes a fix for the issue.

But rather than removing it, this change updates it to reflect what we do know; large bill runs can take 3 hours or more to generate a summary.