### PR TITLE
Add PATCH version of bill run /send endpoint

### DIFF
--- a/openapi/paths/v1/billruns/bill_run_send.yml
+++ b/openapi/paths/v1/billruns/bill_run_send.yml
@@ -1,8 +1,27 @@
-post:
+patch:
   operationId: SendBillRun
-  description: "Triggers (re)generation of summary statistics for the bill run and creation of a transaction file containing all transactions in the bill run.  Bill run must be unbilled and approved."
+  description: "Triggers (re)generation of summary statistics for the bill run and creation of a transaction file containing all transactions in the bill run. Bill run must be unbilled and approved."
   tags:
     - billrun
+  parameters:
+    - $ref: '../../../schema/parameters.yml#/regime'
+    - $ref: '../../../schema/parameters.yml#/billrunId'
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              billRun:
+                $ref: '../../../schema/schemas.yml#/billrun'
+post:
+  operationId: SendBillRun
+  description: "**This endpoint will be removed in the next version of the API**. Does exactly the same thing as the `PATCH` version. It is deprecated and will be removed because it does not meet our convention of using `PATCH` for endpoints like these."
+  tags:
+    - billrun
+  deprecated: true
   parameters:
     - $ref: '../../../schema/parameters.yml#/regime'
     - $ref: '../../../schema/parameters.yml#/billrunId'


### PR DESCRIPTION
See [Create a PATCH version of billrun send endpoint](https://github.com/DEFRA/charging-module-api/pull/156)

The convention in the API is for any endpoint which is used to tell us to do something, for example, 'approve' a bill run, to expect a `PATCH` request. That is apart from 'send' a bill run. That's a `POST`.

Like nails on a blackboard, it causes us pain whenever we see it!

As agreed with the WRLS team we have added a new `PATCH` version of the endpoint to the API which works _exactly_ the same as the existing endpoint. After we've shipped the next version of the API we'll remove the `POST` version.

Doing it this way means we won't break their existing system and allow them time to migrate to using the new `PATCH` version.

This change updates the Open API spec to include the new endpoint and mark the old one as deprecated.