### PR TITLE
Underscores in urls? Oh my!

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -105,8 +105,11 @@ paths:
   '/v1/{regime}/calculate_charge':
     $ref: 'paths/v1/calculate_charge/calculate_charge.yml'
 
-  '/v1/{regime}/customer_changes':
+  '/v1/{regime}/customer-changes':
     $ref: 'paths/v1/customer_changes/customer_changes.yml'
+
+  '/v1/{regime}/customer_changes':
+    $ref: 'paths/v1/customer_changes/deprecated_customer_changes.yml'
 
   '/v1/{regime}/transactions':
     $ref: 'paths/v1/transactions/transactions.yml'

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -102,8 +102,11 @@ paths:
   '/v1/{regime}/billruns/{billrunId}/transactions/{transactionId}':
     $ref: 'paths/v1/billruns/transactions/bill_run_transaction.yml'
 
-  '/v1/{regime}/calculate_charge':
+  '/v1/{regime}/calculate-charge':
     $ref: 'paths/v1/calculate_charge/calculate_charge.yml'
+
+  '/v1/{regime}/calculate_charge':
+    $ref: 'paths/v1/calculate_charge/deprecated_calculate_charge.yml'
 
   '/v1/{regime}/customer-changes':
     $ref: 'paths/v1/customer_changes/customer_changes.yml'

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -69,10 +69,10 @@ paths:
   '/admin/regimes/{regime}':
     $ref: 'paths/admin/regime.yml'
 
-  '/admin/authorised_systems':
+  '/admin/authorised-systems':
     $ref: 'paths/admin/authorised_systems.yml'
 
-  '/admin/authorised_systems/{authorisedSystemId}':
+  '/admin/authorised-systems/{authorisedSystemId}':
     $ref: 'paths/admin/authorised_system.yml'
 
   '/admin/health/airbrake':
@@ -81,10 +81,10 @@ paths:
   '/admin/health/database':
     $ref: 'paths/admin/health/database.yml'
 
-  '/admin/test/{regime}/customer_files':
+  '/admin/test/{regime}/customer-files':
     $ref: 'paths/admin/test/customer_files.yml'
 
-  '/admin/test/{regime}/customer_files/{customerFileId}':
+  '/admin/test/{regime}/customer-files/{customerFileId}':
     $ref: 'paths/admin/test/customer_file.yml'
 
   '/v1/{regime}/billruns/{billrunId}':

--- a/openapi/paths/v1/calculate_charge/deprecated_calculate_charge.yml
+++ b/openapi/paths/v1/calculate_charge/deprecated_calculate_charge.yml
@@ -1,0 +1,52 @@
+post:
+  operationId: CalculateCharge
+  description: "**This endpoint will be removed in the next version of the API**. Does exactly the same thing as the `/calculate-charge` endpoint. It is deprecated and will be removed because it does not follow the standard convention of using dashes instead of underscores."
+  tags:
+    - calculate
+  deprecated: true
+  parameters:
+    - $ref: '../../../schema/parameters.yml#/regime'
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              calculation:
+                $ref: '../../../schema/schemas.yml#/calculateChargeResponse'
+          example:
+            calculation:
+              chargeValue: 772
+              sourceFactor: 3
+              seasonFactor: 1.6
+              lossFactor: 0.03
+              licenceHolderChargeAgreement: null
+              chargeElementAgreement: null
+              eiucSourceFactor: 0
+              eiuc: 0
+              suc: 1495
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../schema/schemas.yml#/calculateCharge'
+        example:
+          periodStart: 01-APR-2020
+          periodEnd: 31-MAR-2021
+          credit: false
+          billableDays: 214
+          authorisedDays: 214
+          volume: '3.5865'
+          source: Supported
+          season: Summer
+          loss: Low
+          twoPartTariff: false
+          compensationCharge: false
+          eiucSource: Tidal
+          waterUndertaker: false
+          regionalChargingArea: Midlands
+          section126Factor: 1
+          section127Agreement: false
+          section130Agreement: false

--- a/openapi/paths/v1/customer_changes/deprecated_customer_changes.yml
+++ b/openapi/paths/v1/customer_changes/deprecated_customer_changes.yml
@@ -1,0 +1,30 @@
+post:
+  operationId: CreateCustomerChange
+  description: "**This endpoint will be removed in the next version of the API**. Does exactly the same thing as the `/customer-change` endpoint. It is deprecated and will be removed because it does not follow the standard convention of using dashes instead of underscores."
+  tags:
+    - customer
+  deprecated: true
+  parameters:
+    - $ref: '../../../schema/parameters.yml#/regime'
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            $ref: '../../../schema/schemas.yml#/customerChangePostResponse'
+          example:
+            customerChange:
+              id: '4643f6c6-dc65-4aaa-883f-f3410b7fa8c8'
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../schema/schemas.yml#/customerChangePost'
+        example:
+          region: A
+          customerReference: BB02BEEB
+          customerName: Huge Factory Ltd
+          addressLine1: 1 Monster Lane
+          addressLine2: High Town
+          addressLine4: Chigley


### PR DESCRIPTION
See [Underscores in URLs? Oh my!](https://github.com/DEFRA/charging-module-api/pull/164)

Most likely it was because that's what the underlying controller/endpoints are called, we seem to have some endpoints that expect an underscore in the path.

It's perfectly permissible. However, it's definitely not the convention for URLs. To quote Google

> Consider using punctuation in your URLs. The URL **http://www.example.com/green-dress.html** is much more useful to us than **http://www.example.com/greendress.html**. We recommend that you use hyphens (-) instead of underscores (_) in your URLs.

So before the API hits a live production environment, we're taking the opportunity to update it to follow the current convention of using dashes.

There is also the 'blackboard' effect on us as a delivery team. It's for this same reason we added a [`PATCH` version of the bill run `/send` endpoint](https://github.com/DEFRA/charging-module-api/pull/156). 🧑‍🏫 😁