### PR TITLE
Update OpenAPI version 2 draft spec with available

### DIFF
--- a/openapi/schema/fields.yml
+++ b/openapi/schema/fields.yml
@@ -2,6 +2,10 @@ abatementAdjustment:
   description: "The factor to apply to the charge where a section 126 charge agreement is relevant to the transaction"
   type: number
   example: 0.5
+admin:
+  description: "Boolean indicator to show whether or not the authorised system is an 'admin' user of the API"
+  type: boolean
+  example: false
 addressLine1:
   description: "First line of billing address for a customer"
   type: string
@@ -51,6 +55,11 @@ authorisedDays:
   minimum: 0
   maximum: 366
   example: 214
+authorisedSystemId:
+  description: "Internal ID (GUID) allocated by the CM when creating an authorised system."
+  type: string
+  format: uuid
+  example: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
 authorisedSystemStatus:
   type: string
   example: 'active'
@@ -281,7 +290,7 @@ regime:
   enum: [cfd, pas, wml, wrls]
   example: 'wrls'
 regimeId:
-  description: "NOT IN MASTER DATA SPECIFICATION"
+  description: "Internal ID (GUID) allocated by the CM when creating a regime."
   type: string
   format: uuid
   example: 'fd2ab097-3097-42bd-849e-046aa250a0d0'

--- a/openapi/schema/parameters.yml
+++ b/openapi/schema/parameters.yml
@@ -2,9 +2,9 @@ authorisedSystemId:
   name: authorisedSystemId
   in: path
   required: true
-  description: "Client ID provided by AWS Cognito"
+  description: "Internal ID (GUID) allocated by the CM when creating an authorised system."
   schema:
-    $ref: 'fields.yml#/clientID'
+    $ref: 'fields.yml#/authorisedSystemId'
 batchNumber:
   name: batchNumber
   in: query
@@ -86,6 +86,13 @@ regime:
   description: "Charging regime to use"
   schema:
     $ref: 'fields.yml#/regime'
+regimeId:
+  name: regimeId
+  in: path
+  required: true
+  description: "Internal ID (GUID) allocated by the CM when creating a regime."
+  schema:
+    $ref: 'fields.yml#/regimeId'
 region:
   name: region
   in: query

--- a/openapi/schema/schemas.yml
+++ b/openapi/schema/schemas.yml
@@ -69,6 +69,21 @@ authorisedSystemPost:
       type: array
       items:
         $ref: 'fields.yml#/regime'
+authorisedSystemPostV2:
+  description: "Essentially the user account of a system authorised to use the API. Includes what authorisations each account has."
+  type: object
+  properties:
+    clientId:
+      $ref: 'fields.yml#/clientID'
+    name:
+      type: string
+      example: 'wrls'
+    status:
+      $ref: 'fields.yml#/authorisedSystemStatus'
+    authorisations:
+      type: array
+      items:
+        $ref: 'fields.yml#/regime'
 authorisedSystemSummary:
   description: "Essentially the user account of a system authorised to use the API. The summarised version does not include what authorisations each account has."
   type: object

--- a/openapi/schema/schemas.yml
+++ b/openapi/schema/schemas.yml
@@ -22,6 +22,25 @@ authorisedSystem:
             $ref: 'fields.yml#/regime'
           last_accessed_at:
             $ref: 'fields.yml#/timeStamp'
+authorisedSystemV2:
+  description: "Essentially the user account of a system authorised to use the API. Includes what regimes each account is authorised to make requests for."
+  type: object
+  properties:
+    id:
+      $ref: 'fields.yml#/authorisedSystemId'
+    clientId:
+      $ref: 'fields.yml#/clientID'
+    name:
+      type: string
+      example: 'wrls'
+    status:
+      $ref: 'fields.yml#/authorisedSystemStatus'
+    admin:
+      $ref: 'fields.yml#/admin'
+    createdAt:
+      $ref: 'fields.yml#/timeStamp'
+    updatedAt:
+      $ref: 'fields.yml#/timeStamp'
 authorisedSystemPatch:
   description: "Essentially the user account of a system authorised to use the API. Includes what authorisations each account has."
   type: object
@@ -430,6 +449,25 @@ regimeSummary:
       example: 'Water Resources'
     slug:
       $ref: 'fields.yml#/regime'
+regimeV2:
+  description: "Charging regime that will have its own charge rules"
+  type: object
+  properties:
+    id:
+      $ref: 'fields.yml#/regimeId'
+    slug:
+      type: string
+      enum: [cfd, pas, wml, wrls]
+      example: 'wrls'
+    name:
+      type: string
+      example: 'Water Resources'
+    preSrocCutoffDate:
+      $ref: 'fields.yml#/timeStamp'
+    createdAt:
+      $ref: 'fields.yml#/timeStamp'
+    updatedAt:
+      $ref: 'fields.yml#/timeStamp'
 status:
   description: "Returned by a call to status, it is an object that contains a copy of the headers found in the original request"
   type: object

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -79,6 +79,9 @@ paths:
   '/v2/{regime}/billruns':
     $ref: 'paths/v2/billruns/bill_runs.yml'
 
+  '/v2/{regime}/billruns/{billrunId}/transactions':
+    $ref: 'paths/v2/billruns/transactions/bill_run_transactions.yml'
+
   '/v2/{regime}/calculate-charge':
     $ref: 'paths/v2/calculate_charge/calculate_charge.yml'
 

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -76,6 +76,9 @@ paths:
   '/admin/health/database':
     $ref: 'paths/admin/health/database.yml'
 
+  '/v2/{regime}/billruns':
+    $ref: 'paths/v2/billruns/bill_runs.yml'
+
   '/v2/{regime}/calculate-charge':
     $ref: 'paths/v2/calculate_charge/calculate_charge.yml'
 

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -58,6 +58,9 @@ paths:
   /status:
     $ref: 'paths/status.yml'
 
+  '/admin/regimes':
+    $ref: 'paths/admin/regimes.yml'
+
   '/admin/regimes/{regimeId}':
     $ref: 'paths/admin/regime.yml'
 

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -64,6 +64,9 @@ paths:
   '/admin/regimes/{regimeId}':
     $ref: 'paths/admin/regime.yml'
 
+  '/admin/authorised-systems':
+    $ref: 'paths/admin/authorised_systems.yml'
+
   '/admin/authorised-systems/{authorisedSystemId}':
     $ref: 'paths/admin/authorised_system.yml'
 

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -76,6 +76,9 @@ paths:
   '/admin/health/database':
     $ref: 'paths/admin/health/database.yml'
 
+  '/v2/{regime}/calculate-charge':
+    $ref: 'paths/v2/calculate_charge/calculate_charge.yml'
+
 security:
   - OAuth2: []
 

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -58,6 +58,12 @@ paths:
   /status:
     $ref: 'paths/status.yml'
 
+  '/admin/regimes/{regimeId}':
+    $ref: 'paths/admin/regime.yml'
+
+  '/admin/authorised-systems/{authorisedSystemId}':
+    $ref: 'paths/admin/authorised_system.yml'
+
   '/admin/health/airbrake':
     $ref: 'paths/admin/health/airbrake.yml'
 

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -58,6 +58,12 @@ paths:
   /status:
     $ref: 'paths/status.yml'
 
+  '/admin/health/airbrake':
+    $ref: 'paths/admin/health/airbrake.yml'
+
+  '/admin/health/database':
+    $ref: 'paths/admin/health/database.yml'
+
 security:
   - OAuth2: []
 

--- a/openapi/version_2/paths/admin/authorised_system.yml
+++ b/openapi/version_2/paths/admin/authorised_system.yml
@@ -1,0 +1,31 @@
+get:
+  operationId: ViewAuthorisedSystem
+  description: "Request details of an 'authorised system'. An authorised system is essentially a user of the API, and this returns details about it including which regimes it is authorised to access."
+  tags:
+    - admin
+  parameters:
+    - $ref: '../../../schema/parameters.yml#/authorisedSystemId'
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              $ref: '../../../schema/schemas.yml#/authorisedSystemV2'
+          example:
+            id: 'b36d674f-b97c-4685-95f3-aacae8c97bde'
+            clientId: '1b1gshltt176v80nsc4fxxxxxx'
+            name: 'wrls'
+            status: 'active'
+            admin: 'false'
+            createdAt: '2020-12-02T09:19:22.065Z'
+            updatedAt: '2020-12-02T09:19:22.065Z'
+            regimes:
+              - id: '2f62bc92-7372-4d2a-979b-792e530c311c'
+                slug: 'wrls'
+                name: 'Water Resources'
+                preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'

--- a/openapi/version_2/paths/admin/authorised_system.yml
+++ b/openapi/version_2/paths/admin/authorised_system.yml
@@ -11,9 +11,7 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              $ref: '../../../schema/schemas.yml#/authorisedSystemV2'
+            $ref: '../../../schema/schemas.yml#/authorisedSystemV2'
           example:
             id: 'b36d674f-b97c-4685-95f3-aacae8c97bde'
             clientId: '1b1gshltt176v80nsc4fxxxxxx'

--- a/openapi/version_2/paths/admin/authorised_systems.yml
+++ b/openapi/version_2/paths/admin/authorised_systems.yml
@@ -1,0 +1,88 @@
+get:
+  operationId: ListAuthorisedSystems
+  description: "Request a list of 'authorised systems'. An authorised system is essentially a user of the API, and this returns those users permitted to access it."
+  tags:
+    - admin
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              authorisedSystems:
+                type: array
+                items:
+                  $ref: '../../../schema/schemas.yml#/authorisedSystemV2'
+          example:
+            - id: 'ac12ac4b-9b9e-4cba-a06f-a90f611a1ef1'
+              clientId: '710uhe3hqumsk2da43foxxxxxx'
+              name: 'admin'
+              status: 'active'
+              admin: 'true'
+              createdAt: '2020-11-01T09:19:22.065Z'
+              updatedAt: '2020-11-01T09:19:22.065Z'
+            - id: 'b36d674f-b97c-4685-95f3-aacae8c97bde'
+              clientId: '1b1gshltt176v80nsc4fxxxxxx'
+              name: 'wrls'
+              status: 'active'
+              admin: 'false'
+              createdAt: '2020-12-02T09:19:22.065Z'
+              updatedAt: '2020-12-02T09:19:22.065Z'
+
+post:
+  operationId: AddAuthorisedSystem
+  description: "Add a new 'authorised system'. An authorised system is essentially a user of the API, and this adds a new one to it."
+  tags:
+    - admin
+  responses:
+    '201':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            $ref: '../../../schema/schemas.yml#/authorisedSystemV2'
+          example:
+            id: '9e76203a-e900-41a1-a045-2551d98e010c'
+            clientId: 'i7rnixijjrawj7azzhwwxxxxxx'
+            name: 'dashboard'
+            status: 'active'
+            admin: 'false'
+            createdAt: '2020-12-04T09:19:22.065Z'
+            updatedAt: '2020-12-04T09:19:22.065Z'
+            regimes:
+              - id: 'ef5ee223-2ee5-4f02-ace5-35330d9f3781'
+                slug: 'cfd'
+                name: 'Water Quality'
+                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+              - id: '6bd74eeb-6beb-41d9-be52-5934a49ecd97'
+                slug: 'pas'
+                name: 'Installations'
+                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+              - id: '458834a2-0541-4981-87f6-2c0ec9261661'
+                slug: 'wml'
+                name: 'Waste'
+                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+              - id: '2f62bc92-7372-4d2a-979b-792e530c311c'
+                slug: 'wrls'
+                name: 'Water Resources'
+                preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../schema/schemas.yml#/authorisedSystemPostV2'
+        example:
+          clientId: 'i7rnixijjrawj7azzhwwxxxxxx'
+          name: 'dashboard'
+          status: 'active'
+          authorisations: [cfd, pas, wml, wrls]

--- a/openapi/version_2/paths/admin/health/airbrake.yml
+++ b/openapi/version_2/paths/admin/health/airbrake.yml
@@ -1,0 +1,8 @@
+get:
+  operationId: CheckAirbrake
+  description: "Used to confirm Airbrake is connected correctly to an environment"
+  tags:
+    - admin
+  responses:
+    '500':
+      description: "An error has been thrown on purpose by the API. Check either the production or non-production instance of Errbit to confirm it received the error"

--- a/openapi/version_2/paths/admin/health/database.yml
+++ b/openapi/version_2/paths/admin/health/database.yml
@@ -1,0 +1,10 @@
+get:
+  operationId: CheckDatabase
+  description: "Used to check the API is correctly connected to the database in an environment. Will also provide some general stats about the data held
+
+  > The endpoint does return a JSON response. However, it's pretty sizable and just a JSON version of [pg_stat_user_tables](http://www.postgresql.cn/docs/10/monitoring-stats.html#PG-STAT-ALL-TABLES-VIEW). So we don't document it here."
+  tags:
+    - admin
+  responses:
+    '200':
+      description: "Success"

--- a/openapi/version_2/paths/admin/regime.yml
+++ b/openapi/version_2/paths/admin/regime.yml
@@ -1,0 +1,31 @@
+get:
+  operationId: ViewRegime
+  description: "Request details of a 'regime'."
+  tags:
+    - admin
+  parameters:
+    - $ref: '../../../schema/parameters.yml#/regimeId'
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              $ref: '../../../schema/schemas.yml#/regimeV2'
+          example:
+            id: '2f62bc92-7372-4d2a-979b-792e530c311c'
+            slug: 'wrls'
+            name: 'Water Resources'
+            preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+            createdAt: '2020-12-01T09:19:22.065Z'
+            updatedAt: '2020-12-01T09:19:22.065Z'
+            authorisedSystems:
+              - id: 'b36d674f-b97c-4685-95f3-aacae8c97bde'
+                clientId: '1b1gshltt176v80nsc4fxxxxxx'
+                name: 'wrls'
+                status: 'active'
+                admin: 'false'
+                createdAt: '2020-12-02T09:19:22.065Z'
+                updatedAt: '2020-12-02T09:19:22.065Z'

--- a/openapi/version_2/paths/admin/regime.yml
+++ b/openapi/version_2/paths/admin/regime.yml
@@ -11,9 +11,7 @@ get:
       content:
         application/json:
           schema:
-            type: object
-            properties:
-              $ref: '../../../schema/schemas.yml#/regimeV2'
+            $ref: '../../../schema/schemas.yml#/regimeV2'
           example:
             id: '2f62bc92-7372-4d2a-979b-792e530c311c'
             slug: 'wrls'

--- a/openapi/version_2/paths/admin/regimes.yml
+++ b/openapi/version_2/paths/admin/regimes.yml
@@ -1,0 +1,39 @@
+get:
+  operationId: ListRegimes
+  description: "Request a list of the charging regimes recognised and managed by the service"
+  tags:
+    - admin
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../../../schema/schemas.yml#/regimeV2'
+          example:
+            - id: 'ef5ee223-2ee5-4f02-ace5-35330d9f3781'
+              slug: 'cfd'
+              name: 'Water Quality'
+              preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+              createdAt: '2020-12-01T09:19:22.065Z'
+              updatedAt: '2020-12-01T09:19:22.065Z'
+            - id: '6bd74eeb-6beb-41d9-be52-5934a49ecd97'
+              slug: 'pas'
+              name: 'Installations'
+              preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+              createdAt: '2020-12-01T09:19:22.065Z'
+              updatedAt: '2020-12-01T09:19:22.065Z'
+            - id: '458834a2-0541-4981-87f6-2c0ec9261661'
+              slug: 'wml'
+              name: 'Waste'
+              preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+              createdAt: '2020-12-01T09:19:22.065Z'
+              updatedAt: '2020-12-01T09:19:22.065Z'
+            - id: '2f62bc92-7372-4d2a-979b-792e530c311c'
+              slug: 'wrls'
+              name: 'Water Resources'
+              preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+              createdAt: '2020-12-01T09:19:22.065Z'
+              updatedAt: '2020-12-01T09:19:22.065Z'

--- a/openapi/version_2/paths/v2/billruns/bill_runs.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_runs.yml
@@ -1,0 +1,25 @@
+post:
+  operationId: CreateBillRun
+  description: "This endpoint triggers creation of a bill run record for a region. Bill run contains no transactions on creation."
+  tags:
+    - billrun
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+  responses:
+    '201':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../schema/schemas.yml#/billrunPostResponse'
+          example:
+            billRun:
+              id: '2bbbe459-966e-4026-b5d2-2f10867bdddd'
+              billRunNumber: 10004
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../../schema/schemas.yml#/billrunPost'
+        example:
+          region: 'A'

--- a/openapi/version_2/paths/v2/billruns/transactions/bill_run_transactions.yml
+++ b/openapi/version_2/paths/v2/billruns/transactions/bill_run_transactions.yml
@@ -1,0 +1,48 @@
+post:
+  operationId: AddBillRunTransaction
+  description: "Triggers creation of a transaction and immediately adds it to the specified bill run."
+  tags:
+    - billrun
+  parameters:
+    - $ref: '../../../../../schema/parameters.yml#/regime'
+    - $ref: '../../../../../schema/parameters.yml#/billrunId'
+  responses:
+    '201':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            $ref: '../../../../../schema/schemas.yml#/transactionPostResponse'
+          example:
+            transaction:
+              id: 'fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3'
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../../../schema/schemas.yml#/transactionPost'
+        example:
+          periodStart: '01-APR-2019'
+          periodEnd: '31-MAR-2020'
+          credit: false
+          billableDays: 310
+          authorisedDays: 365
+          volume: '6.22'
+          source: 'Supported'
+          season: 'Summer'
+          loss: 'Low'
+          twoPartTariff: false
+          compensationCharge: false
+          eiucSource: 'Tidal'
+          waterUndertaker: false
+          regionalChargingArea: 'Anglian'
+          section127Agreement: false
+          section130Agreement: false
+          customerReference: 'TH230000222'
+          lineDescription: 'Well at Chigley Town Hall'
+          licenceNumber: 'TONY/TF9222/37'
+          chargePeriod: '01-APR-2018 - 31-MAR-2019'
+          chargeElementId: ''
+          batchNumber: 'TONY10'
+          region: 'W'
+          areaCode: 'ARCA'

--- a/openapi/version_2/paths/v2/calculate_charge/calculate_charge.yml
+++ b/openapi/version_2/paths/v2/calculate_charge/calculate_charge.yml
@@ -1,0 +1,51 @@
+post:
+  operationId: CalculateCharge
+  description: "Request to calculate a standalone charge based on a set of charge parameters, without creating a transaction. Input and output data is not retained in the CM."
+  tags:
+    - calculate
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              calculation:
+                $ref: '../../../../schema/schemas.yml#/calculateChargeResponse'
+          example:
+            calculation:
+              chargeValue: 772
+              sourceFactor: 3
+              seasonFactor: 1.6
+              lossFactor: 0.03
+              licenceHolderChargeAgreement: null
+              chargeElementAgreement: null
+              eiucSourceFactor: 0
+              eiuc: 0
+              suc: 1495
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: '../../../../schema/schemas.yml#/calculateCharge'
+        example:
+          periodStart: 01-APR-2020
+          periodEnd: 31-MAR-2021
+          credit: false
+          billableDays: 214
+          authorisedDays: 214
+          volume: '3.5865'
+          source: Supported
+          season: Summer
+          loss: Low
+          twoPartTariff: false
+          compensationCharge: false
+          eiucSource: Tidal
+          waterUndertaker: false
+          regionalChargingArea: Midlands
+          section126Factor: 1
+          section127Agreement: false
+          section130Agreement: false

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -78,6 +78,1068 @@ paths:
                   status:
                     type: string
                     example: alive
+  "/admin/regimes":
+    get:
+      operationId: ListRegimes
+      description: Request a list of the charging regimes recognised and managed by
+        the service
+      tags:
+      - admin
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  description: Charging regime that will have its own charge rules
+                  type: object
+                  properties:
+                    id:
+                      description: Internal ID (GUID) allocated by the CM when creating
+                        a regime.
+                      type: string
+                      format: uuid
+                      example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                    slug:
+                      type: string
+                      enum:
+                      - cfd
+                      - pas
+                      - wml
+                      - wrls
+                      example: wrls
+                    name:
+                      type: string
+                      example: Water Resources
+                    preSrocCutoffDate:
+                      description: NOT IN MASTER DATA SPECIFICATION
+                      type: string
+                      format: datetime
+                      example: '2020-09-11T11:56:41.578Z'
+                    createdAt:
+                      description: NOT IN MASTER DATA SPECIFICATION
+                      type: string
+                      format: datetime
+                      example: '2020-09-11T11:56:41.578Z'
+                    updatedAt:
+                      description: NOT IN MASTER DATA SPECIFICATION
+                      type: string
+                      format: datetime
+                      example: '2020-09-11T11:56:41.578Z'
+              example:
+              - id: ef5ee223-2ee5-4f02-ace5-35330d9f3781
+                slug: cfd
+                name: Water Quality
+                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+              - id: 6bd74eeb-6beb-41d9-be52-5934a49ecd97
+                slug: pas
+                name: Installations
+                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+              - id: 458834a2-0541-4981-87f6-2c0ec9261661
+                slug: wml
+                name: Waste
+                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+              - id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                slug: wrls
+                name: Water Resources
+                preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+  "/admin/regimes/{regimeId}":
+    get:
+      operationId: ViewRegime
+      description: Request details of a 'regime'.
+      tags:
+      - admin
+      parameters:
+      - name: regimeId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a regime.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a regime.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                description: Charging regime that will have its own charge rules
+                type: object
+                properties:
+                  id:
+                    description: Internal ID (GUID) allocated by the CM when creating
+                      a regime.
+                    type: string
+                    format: uuid
+                    example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                  slug:
+                    type: string
+                    enum:
+                    - cfd
+                    - pas
+                    - wml
+                    - wrls
+                    example: wrls
+                  name:
+                    type: string
+                    example: Water Resources
+                  preSrocCutoffDate:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+                  createdAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+                  updatedAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+              example:
+                id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                slug: wrls
+                name: Water Resources
+                preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+                authorisedSystems:
+                - id: b36d674f-b97c-4685-95f3-aacae8c97bde
+                  clientId: 1b1gshltt176v80nsc4fxxxxxx
+                  name: wrls
+                  status: active
+                  admin: 'false'
+                  createdAt: '2020-12-02T09:19:22.065Z'
+                  updatedAt: '2020-12-02T09:19:22.065Z'
+  "/admin/authorised-systems":
+    get:
+      operationId: ListAuthorisedSystems
+      description: Request a list of 'authorised systems'. An authorised system is
+        essentially a user of the API, and this returns those users permitted to access
+        it.
+      tags:
+      - admin
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  authorisedSystems:
+                    type: array
+                    items:
+                      description: Essentially the user account of a system authorised
+                        to use the API. Includes what regimes each account is authorised
+                        to make requests for.
+                      type: object
+                      properties:
+                        id:
+                          description: Internal ID (GUID) allocated by the CM when
+                            creating an authorised system.
+                          type: string
+                          format: uuid
+                          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                        clientId:
+                          description: NOT IN MASTER DATA SPECIFICATION
+                          type: string
+                          example: i7rnixijjrawj7azzhwwxxxxxx
+                        name:
+                          type: string
+                          example: wrls
+                        status:
+                          type: string
+                          example: active
+                        admin:
+                          description: Boolean indicator to show whether or not the
+                            authorised system is an 'admin' user of the API
+                          type: boolean
+                          example: false
+                        createdAt:
+                          description: NOT IN MASTER DATA SPECIFICATION
+                          type: string
+                          format: datetime
+                          example: '2020-09-11T11:56:41.578Z'
+                        updatedAt:
+                          description: NOT IN MASTER DATA SPECIFICATION
+                          type: string
+                          format: datetime
+                          example: '2020-09-11T11:56:41.578Z'
+              example:
+              - id: ac12ac4b-9b9e-4cba-a06f-a90f611a1ef1
+                clientId: 710uhe3hqumsk2da43foxxxxxx
+                name: admin
+                status: active
+                admin: 'true'
+                createdAt: '2020-11-01T09:19:22.065Z'
+                updatedAt: '2020-11-01T09:19:22.065Z'
+              - id: b36d674f-b97c-4685-95f3-aacae8c97bde
+                clientId: 1b1gshltt176v80nsc4fxxxxxx
+                name: wrls
+                status: active
+                admin: 'false'
+                createdAt: '2020-12-02T09:19:22.065Z'
+                updatedAt: '2020-12-02T09:19:22.065Z'
+    post:
+      operationId: AddAuthorisedSystem
+      description: Add a new 'authorised system'. An authorised system is essentially
+        a user of the API, and this adds a new one to it.
+      tags:
+      - admin
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                description: Essentially the user account of a system authorised to
+                  use the API. Includes what regimes each account is authorised to
+                  make requests for.
+                type: object
+                properties:
+                  id:
+                    description: Internal ID (GUID) allocated by the CM when creating
+                      an authorised system.
+                    type: string
+                    format: uuid
+                    example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                  clientId:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    example: i7rnixijjrawj7azzhwwxxxxxx
+                  name:
+                    type: string
+                    example: wrls
+                  status:
+                    type: string
+                    example: active
+                  admin:
+                    description: Boolean indicator to show whether or not the authorised
+                      system is an 'admin' user of the API
+                    type: boolean
+                    example: false
+                  createdAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+                  updatedAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+              example:
+                id: 9e76203a-e900-41a1-a045-2551d98e010c
+                clientId: i7rnixijjrawj7azzhwwxxxxxx
+                name: dashboard
+                status: active
+                admin: 'false'
+                createdAt: '2020-12-04T09:19:22.065Z'
+                updatedAt: '2020-12-04T09:19:22.065Z'
+                regimes:
+                - id: ef5ee223-2ee5-4f02-ace5-35330d9f3781
+                  slug: cfd
+                  name: Water Quality
+                  preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                  createdAt: '2020-12-01T09:19:22.065Z'
+                  updatedAt: '2020-12-01T09:19:22.065Z'
+                - id: 6bd74eeb-6beb-41d9-be52-5934a49ecd97
+                  slug: pas
+                  name: Installations
+                  preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                  createdAt: '2020-12-01T09:19:22.065Z'
+                  updatedAt: '2020-12-01T09:19:22.065Z'
+                - id: 458834a2-0541-4981-87f6-2c0ec9261661
+                  slug: wml
+                  name: Waste
+                  preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                  createdAt: '2020-12-01T09:19:22.065Z'
+                  updatedAt: '2020-12-01T09:19:22.065Z'
+                - id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                  slug: wrls
+                  name: Water Resources
+                  preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+                  createdAt: '2020-12-01T09:19:22.065Z'
+                  updatedAt: '2020-12-01T09:19:22.065Z'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: Essentially the user account of a system authorised to
+                use the API. Includes what authorisations each account has.
+              type: object
+              properties:
+                clientId:
+                  description: NOT IN MASTER DATA SPECIFICATION
+                  type: string
+                  example: i7rnixijjrawj7azzhwwxxxxxx
+                name:
+                  type: string
+                  example: wrls
+                status:
+                  type: string
+                  example: active
+                authorisations:
+                  type: array
+                  items:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    enum:
+                    - cfd
+                    - pas
+                    - wml
+                    - wrls
+                    example: wrls
+            example:
+              clientId: i7rnixijjrawj7azzhwwxxxxxx
+              name: dashboard
+              status: active
+              authorisations:
+              - cfd
+              - pas
+              - wml
+              - wrls
+  "/admin/authorised-systems/{authorisedSystemId}":
+    get:
+      operationId: ViewAuthorisedSystem
+      description: Request details of an 'authorised system'. An authorised system
+        is essentially a user of the API, and this returns details about it including
+        which regimes it is authorised to access.
+      tags:
+      - admin
+      parameters:
+      - name: authorisedSystemId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating an authorised
+          system.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating an authorised
+            system.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                description: Essentially the user account of a system authorised to
+                  use the API. Includes what regimes each account is authorised to
+                  make requests for.
+                type: object
+                properties:
+                  id:
+                    description: Internal ID (GUID) allocated by the CM when creating
+                      an authorised system.
+                    type: string
+                    format: uuid
+                    example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                  clientId:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    example: i7rnixijjrawj7azzhwwxxxxxx
+                  name:
+                    type: string
+                    example: wrls
+                  status:
+                    type: string
+                    example: active
+                  admin:
+                    description: Boolean indicator to show whether or not the authorised
+                      system is an 'admin' user of the API
+                    type: boolean
+                    example: false
+                  createdAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+                  updatedAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+              example:
+                id: b36d674f-b97c-4685-95f3-aacae8c97bde
+                clientId: 1b1gshltt176v80nsc4fxxxxxx
+                name: wrls
+                status: active
+                admin: 'false'
+                createdAt: '2020-12-02T09:19:22.065Z'
+                updatedAt: '2020-12-02T09:19:22.065Z'
+                regimes:
+                - id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                  slug: wrls
+                  name: Water Resources
+                  preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+                  createdAt: '2020-12-01T09:19:22.065Z'
+                  updatedAt: '2020-12-01T09:19:22.065Z'
+  "/admin/health/airbrake":
+    get:
+      operationId: CheckAirbrake
+      description: Used to confirm Airbrake is connected correctly to an environment
+      tags:
+      - admin
+      responses:
+        '500':
+          description: An error has been thrown on purpose by the API. Check either
+            the production or non-production instance of Errbit to confirm it received
+            the error
+  "/admin/health/database":
+    get:
+      operationId: CheckDatabase
+      description: |-
+        Used to check the API is correctly connected to the database in an environment. Will also provide some general stats about the data held
+        > The endpoint does return a JSON response. However, it's pretty sizable and just a JSON version of [pg_stat_user_tables](http://www.postgresql.cn/docs/10/monitoring-stats.html#PG-STAT-ALL-TABLES-VIEW). So we don't document it here.
+      tags:
+      - admin
+      responses:
+        '200':
+          description: Success
+  "/v2/{regime}/billruns":
+    post:
+      operationId: CreateBillRun
+      description: This endpoint triggers creation of a bill run record for a region.
+        Bill run contains no transactions on creation.
+      tags:
+      - billrun
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                description: ''
+                type: object
+                properties:
+                  billrun:
+                    type: object
+                    properties:
+                      id:
+                        description: Internal ID (GUID) allocated by the CM when creating
+                          a bill run.
+                        type: string
+                        format: uuid
+                        example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber:
+                        description: The five-digit bill run number of the file generated
+                          by the CM in which the transaction was included
+                        type: integer
+                        minimum: 10000
+                        maximum: 99999
+                        example: 14283
+              example:
+                billRun:
+                  id: 2bbbe459-966e-4026-b5d2-2f10867bdddd
+                  billRunNumber: 10004
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: ''
+              type: object
+              properties:
+                region:
+                  description: A single-digit region identifier for a transaction
+                    or customer
+                  type: string
+                  enum:
+                  - A
+                  - B
+                  - E
+                  - N
+                  - S
+                  - T
+                  - W
+                  - Y
+                  example: A
+              required:
+              - region
+            example:
+              region: A
+  "/v2/{regime}/billruns/{billrunId}/transactions":
+    post:
+      operationId: AddBillRunTransaction
+      description: Triggers creation of a transaction and immediately adds it to the
+        specified bill run.
+      tags:
+      - billrun
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                description: ''
+                type: object
+                properties:
+                  transaction:
+                    type: object
+                    properties:
+                      id:
+                        description: Internal ID (GUID) allocated by the CM when creating
+                          a transaction, not necessarily visible to the user
+                        type: string
+                        format: uuid
+                        example: fd2ab097-3097-42bd-849e-046aa250a0d0
+              example:
+                transaction:
+                  id: fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: ''
+              type: object
+              properties:
+                periodStart:
+                  description: The start date of the charge period covered by a transaction
+                  type: string
+                  example: 01-APR-2018
+                periodEnd:
+                  description: The end date of the charge period covered by a transaction
+                  type: string
+                  example: 31-MAR-2019
+                credit:
+                  description: Boolean indicator to show whether the transaction is
+                    a credit (negative value)
+                  type: boolean
+                  example: false
+                billableDays:
+                  description: The number of days covered by a charge
+                  type: integer
+                  minimum: 0
+                  maximum: 366
+                  example: 149
+                authorisedDays:
+                  description: The number of days per year in which abstraction is
+                    authorised under the terms of the licence
+                  type: integer
+                  minimum: 0
+                  maximum: 366
+                  example: 214
+                volume:
+                  description: The volume (in thousands of cubic metres) on which
+                    the charge is based
+                  type: number
+                  minimum: 0
+                  example: 19.909
+                source:
+                  description: Source on which standard charge calculation based
+                  type: string
+                  enum:
+                  - Supported
+                  - Kielder
+                  - Unsupported
+                  - Tidal
+                  example: Unsupported
+                season:
+                  description: Season on which charge calculation based
+                  type: string
+                  enum:
+                  - Summer
+                  - Winter
+                  - All Year
+                  example: Summer
+                loss:
+                  description: Loss on which charge calculation based
+                  type: string
+                  enum:
+                  - High
+                  - Medium
+                  - Low
+                  - Very Low
+                  example: Medium
+                twoPartTariff:
+                  description: Boolean indicator to show whether the transaction is
+                    for the second part of a 2-part tariff charge
+                  type: boolean
+                  example: true
+                compensationCharge:
+                  description: Boolean indicator to show whether the transaction relates
+                    to a compensation charge
+                  type: boolean
+                  example: false
+                eiucSource:
+                  description: Source on which compensation charge calculation based.
+                    This field is required when creating a transacton if `compensationCharge`
+                    is set to `true`
+                  type: string
+                  example: Tidal
+                waterUndertaker:
+                  description: Boolean indicator to show whether the transaction is
+                    for a water undertaker
+                  type: boolean
+                  example: false
+                regionalChargingArea:
+                  description: The name of the region relevant to the determination
+                    of the SUC and / or EIUC value to be used in the calculation
+                  type: string
+                  enum:
+                  - Anglian
+                  - Midlands
+                  - South West
+                  - North West
+                  - Southern
+                  - Thames
+                  - Northumbria
+                  - Yorkshire
+                  - Wales
+                  example: Northumbria
+                section127Agreement:
+                  description: Indicator to show whether a section 127 charge agreement
+                    applies to the transaction
+                  type: boolean
+                  example: false
+                section130Agreement:
+                  description: Indicator to show whether a section 130 charge agreement
+                    applies to the transaction
+                  type: boolean
+                  example: true
+                customerReference:
+                  description: Customer Number of the invoicee
+                  type: string
+                  example: B19120000A
+                lineDescription:
+                  description: Description of the reason for the charge, to appear
+                    on the invoice sent to the customer
+                  type: string
+                  maxLength: 240
+                  example: Borehole at Runhall, Norfolk.
+                licenceNumber:
+                  description: The reference of the licence to which a charge / transaction
+                    relates
+                  type: string
+                  maxLength: 150
+                  example: 7/34/16/*G/0093
+                chargePeriod:
+                  description: The charge period for a transaction (i.e. charge period
+                    start date to charge period end date)
+                  type: string
+                  example: 01-APR-2018 - 31-MAR-2019
+                chargeElementId:
+                  description: An indicator (normally an integer) to distinguish between
+                    the different charge elements on a specific licence.
+                  type: string
+                  nullable: true
+                  example: '1'
+                batchNumber:
+                  description: Number to be generated by WRLS indicating the 'batch'
+                    in which creation of a transaction was requested
+                  type: string
+                  nullable: true
+                  example: TONY100
+                region:
+                  description: A single-digit region identifier for a transaction
+                    or customer
+                  type: string
+                  enum:
+                  - A
+                  - B
+                  - E
+                  - N
+                  - S
+                  - T
+                  - W
+                  - Y
+                  example: A
+                areaCode:
+                  description: Code identifying the historic area (within a region)
+                    for the transaction.
+                  type: string
+                  enum:
+                  - ARCA
+                  - AREA
+                  - ARNA
+                  - CASC
+                  - MIDLS
+                  - MIDLT
+                  - MIDUS
+                  - MIDUT
+                  - AACOR
+                  - AADEV
+                  - AANWX
+                  - AASWX
+                  - NWCEN
+                  - NWNTH
+                  - NWSTH
+                  - HAAR
+                  - KAEA
+                  - SAAR
+                  - AGY2N
+                  - AGY2S
+                  - AGY3
+                  - AGY3N
+                  - AGY3S
+                  - AGY4N
+                  - AGY4S
+                  - N
+                  - SE
+                  - SE1
+                  - SE2
+                  - SW
+                  - ABNRTH
+                  - DALES
+                  - NAREA
+                  - RIDIN
+                  - DEFAULT
+                  - MULTI
+                  example: NWCEN
+                newLicence:
+                  description: Boolean indicator to show whether a transaction has
+                    arisen as the result of a new licence being created (note that
+                    'new' may also incorporate licence renewals or transfers of a
+                    licence to a new customer)
+                  type: boolean
+                  example: false
+                clientId:
+                  description: ID of the transaction in the client system. If provided
+                    at the time of creation the API will first check no existing transactions
+                    with the same ID for that regime exist.
+                  type: string
+                  nullable: true
+                  example: hb3ab097-8567-42bd-849e-046aa250a8u8
+              required:
+              - region
+              - periodStart
+              - periodEnd
+              - customerReference
+              - licenceNumber
+              - billableDays
+              - authorisedDays
+              - volume
+              - source
+              - season
+              - loss
+              - section130Agreement
+              - section127Agreement
+              - twoPartTariff
+              - compensationCharge
+              - regionalChargingArea
+              - credit
+              - areaCode
+              - lineDescription
+              - waterUndertaker
+              - chargePeriod
+            example:
+              periodStart: 01-APR-2019
+              periodEnd: 31-MAR-2020
+              credit: false
+              billableDays: 310
+              authorisedDays: 365
+              volume: '6.22'
+              source: Supported
+              season: Summer
+              loss: Low
+              twoPartTariff: false
+              compensationCharge: false
+              eiucSource: Tidal
+              waterUndertaker: false
+              regionalChargingArea: Anglian
+              section127Agreement: false
+              section130Agreement: false
+              customerReference: TH230000222
+              lineDescription: Well at Chigley Town Hall
+              licenceNumber: TONY/TF9222/37
+              chargePeriod: 01-APR-2018 - 31-MAR-2019
+              chargeElementId: ''
+              batchNumber: TONY10
+              region: W
+              areaCode: ARCA
+  "/v2/{regime}/calculate-charge":
+    post:
+      operationId: CalculateCharge
+      description: Request to calculate a standalone charge based on a set of charge
+        parameters, without creating a transaction. Input and output data is not retained
+        in the CM.
+      tags:
+      - calculate
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  calculation:
+                    description: ''
+                    type: object
+                    properties:
+                      chargeValue:
+                        description: The value of the transaction in pounds and pence,
+                          as calculated by the rules service
+                        type: number
+                        example: 929
+                      sourceFactor:
+                        description: The source factor applied to the calculation
+                        type: number
+                        example: 9
+                      seasonFactor:
+                        description: The season factor applied to the calculation
+                        type: number
+                        example: 0.16
+                      lossFactor:
+                        description: The loss factor applied to the calculation
+                        type: number
+                        example: 0.003
+                      licenceHolderChargeAgreement:
+                        description: Summary of the Section 130 charge calculation
+                          in a specific format required by the transaction file
+                        type: string
+                        nullable: true
+                        example: S130U x 0.5
+                      chargeElementAgreement:
+                        description: Summary of the Section 126 or Section 127 charge
+                          calculations in a specific format required by the transaction
+                          file
+                        type: string
+                        nullable: true
+                        example: S126 x 0.8
+                      eiucSourceFactor:
+                        description: The EIUC adjusted source factor applied to the
+                          calculation
+                        type: number
+                        example: 0.2
+                      eiuc:
+                        description: Environmental Improvement Unit Charge (EIUC)
+                          for the transaction
+                        type: number
+                        example: 0.2
+                      suc:
+                        description: Standard Unit Charge (SUC) for the transaction
+                        type: number
+                        example: 27.51
+              example:
+                calculation:
+                  chargeValue: 772
+                  sourceFactor: 3
+                  seasonFactor: 1.6
+                  lossFactor: 0.03
+                  licenceHolderChargeAgreement:
+                  chargeElementAgreement:
+                  eiucSourceFactor: 0
+                  eiuc: 0
+                  suc: 1495
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: ''
+              type: object
+              properties:
+                periodStart:
+                  description: The start date of the charge period covered by a transaction
+                  type: string
+                  example: 01-APR-2018
+                periodEnd:
+                  description: The end date of the charge period covered by a transaction
+                  type: string
+                  example: 31-MAR-2019
+                credit:
+                  description: Boolean indicator to show whether the transaction is
+                    a credit (negative value)
+                  type: boolean
+                  example: false
+                billableDays:
+                  description: The number of days covered by a charge
+                  type: integer
+                  minimum: 0
+                  maximum: 366
+                  example: 149
+                authorisedDays:
+                  description: The number of days per year in which abstraction is
+                    authorised under the terms of the licence
+                  type: integer
+                  minimum: 0
+                  maximum: 366
+                  example: 214
+                volume:
+                  description: The volume (in thousands of cubic metres) on which
+                    the charge is based
+                  type: number
+                  minimum: 0
+                  example: 19.909
+                source:
+                  description: Source on which standard charge calculation based
+                  type: string
+                  enum:
+                  - Supported
+                  - Kielder
+                  - Unsupported
+                  - Tidal
+                  example: Unsupported
+                season:
+                  description: Season on which charge calculation based
+                  type: string
+                  enum:
+                  - Summer
+                  - Winter
+                  - All Year
+                  example: Summer
+                loss:
+                  description: Loss on which charge calculation based
+                  type: string
+                  enum:
+                  - High
+                  - Medium
+                  - Low
+                  - Very Low
+                  example: Medium
+                twoPartTariff:
+                  description: Boolean indicator to show whether the transaction is
+                    for the second part of a 2-part tariff charge
+                  type: boolean
+                  example: true
+                compensationCharge:
+                  description: Boolean indicator to show whether the transaction relates
+                    to a compensation charge
+                  type: boolean
+                  example: false
+                eiucSource:
+                  description: Source on which compensation charge calculation based
+                  type: string
+                  example: Tidal
+                waterUndertaker:
+                  description: Boolean indicator to show whether the transaction is
+                    for a water undertaker
+                  type: boolean
+                  example: false
+                regionalChargingArea:
+                  description: The name of the region relevant to the determination
+                    of the SUC and / or EIUC value to be used in the calculation
+                  type: string
+                  enum:
+                  - Anglian
+                  - Midlands
+                  - South West
+                  - North West
+                  - Southern
+                  - Thames
+                  - Northumbria
+                  - Yorkshire
+                  - Wales
+                  example: Northumbria
+                section126Factor:
+                  description: The factor to apply to the charge where a section 126
+                    charge agreement is relevant to the transaction
+                  type: number
+                  minimum: 0
+                  maximum: 1
+                  example: 0.75
+                section127Agreement:
+                  description: Indicator to show whether a section 127 charge agreement
+                    applies to the transaction
+                  type: boolean
+                  example: false
+                section130Agreement:
+                  description: Indicator to show whether a section 130 charge agreement
+                    applies to the transaction
+                  type: boolean
+                  example: true
+              required:
+              - periodStart
+              - periodEnd
+              - billableDays
+              - authorisedDays
+              - volume
+              - source
+              - season
+              - loss
+              - section130Agreement
+              - section127Agreement
+              - twoPartTariff
+              - compensationCharge
+              - regionalChargingArea
+              - credit
+              - waterUndertaker
+            example:
+              periodStart: 01-APR-2020
+              periodEnd: 31-MAR-2021
+              credit: false
+              billableDays: 214
+              authorisedDays: 214
+              volume: '3.5865'
+              source: Supported
+              season: Summer
+              loss: Low
+              twoPartTariff: false
+              compensationCharge: false
+              eiucSource: Tidal
+              waterUndertaker: false
+              regionalChargingArea: Midlands
+              section126Factor: 1
+              section127Agreement: false
+              section130Agreement: false
 security:
 - OAuth2: []
 components:


### PR DESCRIPTION
This update covers updating the spec to include those endpoints that are actually available for use in V2 of the API.