### PR TITLE
Add generate bill run summary endpoint

### DIFF
--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -79,6 +79,9 @@ paths:
   '/v2/{regime}/billruns':
     $ref: 'paths/v2/billruns/bill_runs.yml'
 
+  '/v2/{regime}/billruns/{billrunId}/generate':
+    $ref: 'paths/v2/billruns/bill_run_generate.yml'
+
   '/v2/{regime}/billruns/{billrunId}/transactions':
     $ref: 'paths/v2/billruns/transactions/bill_run_transactions.yml'
 

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -76,13 +76,13 @@ paths:
   '/admin/health/database':
     $ref: 'paths/admin/health/database.yml'
 
-  '/v2/{regime}/billruns':
+  '/v2/{regime}/bill-runs':
     $ref: 'paths/v2/billruns/bill_runs.yml'
 
-  '/v2/{regime}/billruns/{billrunId}/generate':
+  '/v2/{regime}/bill-runs/{billrunId}/generate':
     $ref: 'paths/v2/billruns/bill_run_generate.yml'
 
-  '/v2/{regime}/billruns/{billrunId}/transactions':
+  '/v2/{regime}/bill-runs/{billrunId}/transactions':
     $ref: 'paths/v2/billruns/transactions/bill_run_transactions.yml'
 
   '/v2/{regime}/calculate-charge':

--- a/openapi/version_2/paths/v2/billruns/bill_run_generate.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_generate.yml
@@ -1,0 +1,13 @@
+patch:
+  operationId: GenerateBillRun
+  description: "Generate the summary for the specified bill run. Bill run must be unbilled. Must take place before bill run is sent."
+  tags:
+    - billrun
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+    - $ref: '../../../../schema/parameters.yml#/billrunId'
+  responses:
+    '204':
+      description: "Success"
+    '409':
+      description: "Conflict - status of the bill run means the summary cannot be generated. For example, the bill run is billed or the summary has already been generated."


### PR DESCRIPTION
One of the key changes in Version 2 is that we are breaking up the functionality covered in the Version 1 view bill run endpoint.

At this time V1

- will generate the summary if one does not exist
- return a holding response until the summary is generated
- return a view of the bill run that includes _all_ transactions

On that last point we have bill runs with more than 9,000 transactions. When you add all the invoice summary information the response becomes massive!

So the first part of breaking it up is to create a dedicated `generate-summary` endpoint.

We not actually built it yet. But for this endpoint its not a case of if, but when. So we are adding it now to the open api spec to aid with discussion about it.