### PR TITLE
Add view bill run endpoint

### DIFF
--- a/openapi/schema/schemas.yml
+++ b/openapi/schema/schemas.yml
@@ -198,6 +198,90 @@ billrun:
       $ref: 'fields.yml#/transactionFileReferenceDat'
     transactionFileDate:
       $ref: 'fields.yml#/transactionDate'
+billrunV2:
+  description: ""
+  type: object
+  properties:
+    id:
+      $ref: 'fields.yml#/billrunId'
+    billRunNumber:
+      $ref: 'fields.yml#/billrunNumber'
+    region:
+      $ref: 'fields.yml#/regionCode'
+    status:
+      $ref: 'fields.yml#/billrunStatus'
+    approvedForBilling:
+      $ref: 'fields.yml#/approvalStatus'
+    preSroc:
+      $ref: 'fields.yml#/preSroc'
+    summary:
+      type: object
+      properties:
+        creditNoteCount:
+          type: integer
+          example: 0
+        creditNoteValue:
+          type: integer
+          example: 0
+        invoiceCount:
+          type: integer
+          example: 2
+        invoiceValue:
+          type: integer
+          example: 4593
+        creditLineCount:
+          type: integer
+          example: 0
+        creditLineValue:
+          type: integer
+          example: 0
+        debitLineCount:
+          type: integer
+          example: 3
+        debitLineValue:
+          type: integer
+          example: 4593
+        zeroValueLineCount:
+          type: integer
+          example: 0
+        netTotal:
+          type: integer
+          example: 4593
+    invoices:
+      type: array
+      items:
+        type: object
+        properties:
+          customerReference:
+            $ref: 'fields.yml#/customerReference'
+          summaryByFinancialYear:
+            type: array
+            items:
+              type: object
+              properties:
+                financialYear:
+                  $ref: 'fields.yml#/financialYear'
+                creditLineCount:
+                  type: integer
+                  example: 0
+                creditLineValue:
+                  type: integer
+                  example: 0
+                debitLineCount:
+                  type: integer
+                  example: 2
+                debitLineValue:
+                  type: integer
+                  example: 2500
+                netTotal:
+                  type: integer
+                  example: 2500
+                deminimis:
+                  $ref: 'fields.yml#/deminimisTransaction'
+    transactionFileReference:
+      $ref: 'fields.yml#/transactionFileReferenceDat'
+    transactionFileDate:
+      $ref: 'fields.yml#/transactionDate'
 billrunPost:
   description: ""
   type: object

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -79,6 +79,9 @@ paths:
   '/v2/{regime}/bill-runs':
     $ref: 'paths/v2/billruns/bill_runs.yml'
 
+  '/v2/{regime}/billruns/{billrunId}':
+    $ref: 'paths/v2/billruns/bill_run.yml'
+
   '/v2/{regime}/bill-runs/{billrunId}/generate':
     $ref: 'paths/v2/billruns/bill_run_generate.yml'
 

--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -1,0 +1,133 @@
+get:
+  operationId: ViewBillRun
+  description: "Request to view a single bill run based on the bill run ID."
+  tags:
+    - billrun
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+    - $ref: '../../../../schema/parameters.yml#/billrunId'
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              billRun:
+                $ref: '../../../../schema/schemas.yml#/billrunV2'
+          examples:
+            '01 Just created':
+              value:
+                billRun:
+                  id: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
+                  billRunNumber: 10001
+                  region: 'W'
+                  status: 'initialised'
+                  approvedForBilling: false
+                  preSroc: true
+                  summary:
+                    creditNoteCount: 0
+                    creditNoteValue: 0
+                    invoiceCount: 0
+                    invoiceValue: 0
+                    creditLineCount: 0
+                    creditLineValue: 0
+                    debitLineCount: 0
+                    debitLineValue: 0
+                    zeroValueLineCount: 0
+                    netTotal: 0
+                  invoices: []
+            '02 Transactions added':
+              value:
+                billRun:
+                  id: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
+                  billRunNumber: 10001
+                  region: 'W'
+                  status: 'initialised'
+                  approvedForBilling: false
+                  preSroc: true
+                  summary:
+                    creditNoteCount: 0
+                    creditNoteValue: 0
+                    invoiceCount: 0
+                    invoiceValue: 0
+                    creditLineCount: 0
+                    creditLineValue: 0
+                    debitLineCount: 2
+                    debitLineValue: 2500
+                    zeroValueLineCount: 0
+                    netTotal: 2500
+                  invoices:
+                  - customerReference: 'TH150000020'
+                    summaryByFinancialYear:
+                    - financialYear: 2019
+                      creditLineCount: 0
+                      creditLineValue: 0
+                      debitLineCount: 2
+                      debitLineValue: 2500
+                      zeroValueLineCount: 0
+                      netTotal: 2500
+                      deminimis: false
+            '03 Generating summary':
+              value:
+                billRun:
+                  id: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
+                  billRunNumber: 10001
+                  region: 'W'
+                  status: 'generating'
+                  approvedForBilling: false
+                  preSroc: true
+                  summary:
+                    creditNoteCount: 0
+                    creditNoteValue: 0
+                    invoiceCount: 0
+                    invoiceValue: 0
+                    creditLineCount: 0
+                    creditLineValue: 0
+                    debitLineCount: 2
+                    debitLineValue: 2500
+                    zeroValueLineCount: 0
+                    netTotal: 2500
+                  invoices:
+                  - customerReference: 'TH150000020'
+                    summaryByFinancialYear:
+                    - financialYear: 2019
+                      creditLineCount: 0
+                      creditLineValue: 0
+                      debitLineCount: 2
+                      debitLineValue: 2500
+                      zeroValueLineCount: 0
+                      netTotal: 2500
+                      deminimis: false
+            '04 Summary generated':
+              value:
+                billRun:
+                  id: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
+                  billRunNumber: 10001
+                  region: 'W'
+                  status: 'summarised'
+                  approvedForBilling: false
+                  preSroc: true
+                  summary:
+                    creditNoteCount: 0
+                    creditNoteValue: 0
+                    invoiceCount: 1
+                    invoiceValue: 2500
+                    creditLineCount: 0
+                    creditLineValue: 0
+                    debitLineCount: 2
+                    debitLineValue: 2500
+                    zeroValueLineCount: 0
+                    netTotal: 2500
+                  invoices:
+                  - customerReference: 'TH150000020'
+                    summaryByFinancialYear:
+                    - financialYear: 2019
+                      creditLineCount: 0
+                      creditLineValue: 0
+                      debitLineCount: 2
+                      debitLineValue: 2500
+                      zeroValueLineCount: 0
+                      netTotal: 2500
+                      deminimis: false

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -513,7 +513,7 @@ paths:
       responses:
         '200':
           description: Success
-  "/v2/{regime}/billruns":
+  "/v2/{regime}/bill-runs":
     post:
       operationId: CreateBillRun
       description: This endpoint triggers creation of a bill run record for a region.
@@ -588,7 +588,341 @@ paths:
               - region
             example:
               region: A
-  "/v2/{regime}/billruns/{billrunId}/transactions":
+  "/v2/{regime}/billruns/{billrunId}":
+    get:
+      operationId: ViewBillRun
+      description: Request to view a single bill run based on the bill run ID.
+      tags:
+      - billrun
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  billRun:
+                    description: ''
+                    type: object
+                    properties:
+                      id:
+                        description: Internal ID (GUID) allocated by the CM when creating
+                          a bill run.
+                        type: string
+                        format: uuid
+                        example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber:
+                        description: The five-digit bill run number of the file generated
+                          by the CM in which the transaction was included
+                        type: integer
+                        minimum: 10000
+                        maximum: 99999
+                        example: 14283
+                      region:
+                        description: A single-digit region identifier for a transaction
+                          or customer
+                        type: string
+                        enum:
+                        - A
+                        - B
+                        - E
+                        - N
+                        - S
+                        - T
+                        - W
+                        - Y
+                        example: A
+                      status:
+                        description: Indicator to show the progress of a bill run
+                          towards billed status
+                        type: string
+                        enum:
+                        - billed
+                        - billing_not_required
+                        - generating_summary
+                        - initialised
+                        - pending
+                        example: billed
+                      approvedForBilling:
+                        description: Boolean indicator to show whether or not a user
+                          has confirmed that the transaction is ready to be included
+                          in a transaction file
+                        type: boolean
+                        example: true
+                      preSroc:
+                        description: Boolean indicator to show whether a bill run
+                          is for pre-SRoC or SRoC (where true indicates pre-SRoC and
+                          false is SRoC)
+                        type: boolean
+                        example: true
+                      summary:
+                        type: object
+                        properties:
+                          creditNoteCount:
+                            type: integer
+                            example: 0
+                          creditNoteValue:
+                            type: integer
+                            example: 0
+                          invoiceCount:
+                            type: integer
+                            example: 2
+                          invoiceValue:
+                            type: integer
+                            example: 4593
+                          creditLineCount:
+                            type: integer
+                            example: 0
+                          creditLineValue:
+                            type: integer
+                            example: 0
+                          debitLineCount:
+                            type: integer
+                            example: 3
+                          debitLineValue:
+                            type: integer
+                            example: 4593
+                          zeroValueLineCount:
+                            type: integer
+                            example: 0
+                          netTotal:
+                            type: integer
+                            example: 4593
+                      invoices:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            customerReference:
+                              description: Customer Number of the invoicee
+                              type: string
+                              example: B19120000A
+                            summaryByFinancialYear:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  financialYear:
+                                    description: The financial year (1 April to 31
+                                      March) within which the charge period of a transaction
+                                      falls
+                                    type: integer
+                                    minimum: 2014
+                                    example: 2019
+                                  creditLineCount:
+                                    type: integer
+                                    example: 0
+                                  creditLineValue:
+                                    type: integer
+                                    example: 0
+                                  debitLineCount:
+                                    type: integer
+                                    example: 2
+                                  debitLineValue:
+                                    type: integer
+                                    example: 2500
+                                  netTotal:
+                                    type: integer
+                                    example: 2500
+                                  deminimis:
+                                    description: Boolean flag to indicate whether
+                                      a transaction was part of an invoice that was
+                                      not included in a transaction file (i.e not
+                                      charged to the customer) due to falling below
+                                      the de-minimis value of £5
+                                    type: boolean
+                                    example: false
+                      transactionFileReference:
+                        description: NOT IN MASTER DATA SPECIFICATION
+                        type: string
+                        example: nalai50001.dat
+                      transactionFileDate:
+                        description: Estimated date of issue of the invoice.  In reality
+                          this will be the date of generation of the transaction file,
+                          and SSCL will over-write it with the actual invoice date
+                          on receipt of the transaction file
+                        type: string
+                        nullable: true
+                        example: 03-JUN-2020
+              examples:
+                01 Just created:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: initialised
+                      approvedForBilling: false
+                      preSroc: true
+                      summary:
+                        creditNoteCount: 0
+                        creditNoteValue: 0
+                        invoiceCount: 0
+                        invoiceValue: 0
+                        creditLineCount: 0
+                        creditLineValue: 0
+                        debitLineCount: 0
+                        debitLineValue: 0
+                        zeroValueLineCount: 0
+                        netTotal: 0
+                      invoices: []
+                02 Transactions added:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: initialised
+                      approvedForBilling: false
+                      preSroc: true
+                      summary:
+                        creditNoteCount: 0
+                        creditNoteValue: 0
+                        invoiceCount: 0
+                        invoiceValue: 0
+                        creditLineCount: 0
+                        creditLineValue: 0
+                        debitLineCount: 2
+                        debitLineValue: 2500
+                        zeroValueLineCount: 0
+                        netTotal: 2500
+                      invoices:
+                      - customerReference: TH150000020
+                        summaryByFinancialYear:
+                        - financialYear: 2019
+                          creditLineCount: 0
+                          creditLineValue: 0
+                          debitLineCount: 2
+                          debitLineValue: 2500
+                          zeroValueLineCount: 0
+                          netTotal: 2500
+                          deminimis: false
+                03 Generating summary:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: generating
+                      approvedForBilling: false
+                      preSroc: true
+                      summary:
+                        creditNoteCount: 0
+                        creditNoteValue: 0
+                        invoiceCount: 0
+                        invoiceValue: 0
+                        creditLineCount: 0
+                        creditLineValue: 0
+                        debitLineCount: 2
+                        debitLineValue: 2500
+                        zeroValueLineCount: 0
+                        netTotal: 2500
+                      invoices:
+                      - customerReference: TH150000020
+                        summaryByFinancialYear:
+                        - financialYear: 2019
+                          creditLineCount: 0
+                          creditLineValue: 0
+                          debitLineCount: 2
+                          debitLineValue: 2500
+                          zeroValueLineCount: 0
+                          netTotal: 2500
+                          deminimis: false
+                04 Summary generated:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: summarised
+                      approvedForBilling: false
+                      preSroc: true
+                      summary:
+                        creditNoteCount: 0
+                        creditNoteValue: 0
+                        invoiceCount: 1
+                        invoiceValue: 2500
+                        creditLineCount: 0
+                        creditLineValue: 0
+                        debitLineCount: 2
+                        debitLineValue: 2500
+                        zeroValueLineCount: 0
+                        netTotal: 2500
+                      invoices:
+                      - customerReference: TH150000020
+                        summaryByFinancialYear:
+                        - financialYear: 2019
+                          creditLineCount: 0
+                          creditLineValue: 0
+                          debitLineCount: 2
+                          debitLineValue: 2500
+                          zeroValueLineCount: 0
+                          netTotal: 2500
+                          deminimis: false
+  "/v2/{regime}/bill-runs/{billrunId}/generate":
+    patch:
+      operationId: GenerateBillRun
+      description: Generate the summary for the specified bill run. Bill run must
+        be unbilled. Must take place before bill run is sent.
+      tags:
+      - billrun
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '204':
+          description: Success
+        '409':
+          description: Conflict - status of the bill run means the summary cannot
+            be generated. For example, the bill run is billed or the summary has already
+            been generated.
+  "/v2/{regime}/bill-runs/{billrunId}/transactions":
     post:
       operationId: AddBillRunTransaction
       description: Triggers creation of a transaction and immediately adds it to the


### PR DESCRIPTION
One of the key changes in Version 2 is that we are breaking up the functionality covered in the Version 1 view bill run endpoint.

At this time V1

- will generate the summary if one does not exist
- return a holding response until the summary is generated
- return a view of the bill run that includes _all_ transactions

On that last point, we have bill runs with more than 9,000 transactions. When you add all the invoice summary information the response becomes massive!

We've already updated the Version 2 spec with the proposed 'generate summary' endpoint. This change adds details on view bill run, and how we intend to change it from version 1.

We will now just return what bill run and invoice information we hold in the database; no holding response and no hiding the data if the summary is not generated.

The structure of the response will always be the same, the key element being `status` will always be returned.

N.B. We've not actually built it yet. But for this endpoint, it's not a case of if, but when. So we are adding it now to the open API spec to aid with discussion about these changes.