### PR TITLE
Add bill run send endpoint

### DIFF
--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -85,6 +85,9 @@ paths:
   '/v2/{regime}/bill-runs/{billrunId}/generate':
     $ref: 'paths/v2/billruns/bill_run_generate.yml'
 
+  '/v2/{regime}/billruns/{billrunId}/send':
+    $ref: 'paths/v2/billruns/bill_run_send.yml'
+
   '/v2/{regime}/bill-runs/{billrunId}/transactions':
     $ref: 'paths/v2/billruns/transactions/bill_run_transactions.yml'
 

--- a/openapi/version_2/paths/v2/billruns/bill_run_send.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_send.yml
@@ -1,0 +1,25 @@
+patch:
+  operationId: SendBillRun
+  description: "Triggers creation of a transaction file containing all transactions in the bill run. Bill run must be `approved` else the request will be rejected."
+  tags:
+    - billrun
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+    - $ref: '../../../../schema/parameters.yml#/billrunId'
+  responses:
+    '204':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              billRun:
+                type: object
+                properties:
+                  transactionFileReference:
+                    $ref: '../../../../schema/fields.yml#/transactionFileReferenceDat'
+                  transactionFileDate:
+                    $ref: '../../../../schema/fields.yml#/transactionDate'
+    '409':
+      description: "Conflict - status of the bill run means the summary cannot be generated. For example, the bill run is not approved or is already billed."

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -922,6 +922,64 @@ paths:
           description: Conflict - status of the bill run means the summary cannot
             be generated. For example, the bill run is billed or the summary has already
             been generated.
+  "/v2/{regime}/billruns/{billrunId}/send":
+    patch:
+      operationId: SendBillRun
+      description: Triggers creation of a transaction file containing all transactions
+        in the bill run. Bill run must be `approved` else the request will be rejected.
+      tags:
+      - billrun
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '204':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  billRun:
+                    type: object
+                    properties:
+                      transactionFileReference:
+                        description: NOT IN MASTER DATA SPECIFICATION
+                        type: string
+                        example: nalai50001.dat
+                      transactionFileDate:
+                        description: Estimated date of issue of the invoice.  In reality
+                          this will be the date of generation of the transaction file,
+                          and SSCL will over-write it with the actual invoice date
+                          on receipt of the transaction file
+                        type: string
+                        nullable: true
+                        example: 03-JUN-2020
+        '409':
+          description: Conflict - status of the bill run means the summary cannot
+            be generated. For example, the bill run is not approved or is already
+            billed.
   "/v2/{regime}/bill-runs/{billrunId}/transactions":
     post:
       operationId: AddBillRunTransaction


### PR DESCRIPTION
We've not yet implemented this endpoint in Version 2. But we do intend to make some changes when we do. So to facilitate the final design and implementation this change adds the endpoint with the proposed changes.

For reference, those changes are

- It will not longer generate the summary if this has not been done. Instead it will reject the request
- It will just return the file name the bill run will be assigned to instead of the full bill run summary