### PR TITLE
Add invoice and licence delete endpoints to spec

### DIFF
--- a/openapi/schema/fields.yml
+++ b/openapi/schema/fields.yml
@@ -216,11 +216,21 @@ invoiceDate:
   type: string
   nullable: true
   example: 03-JUN-2020
+invoiceId:
+  description: "Internal ID (GUID) allocated by the CM when creating an invoice."
+  type: string
+  format: uuid
+  example: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
 licenceHolderChargeAgreement:
   description: "Summary of the Section 130 charge calculation in a specific format required by the transaction file"
   type: string
   nullable: true
   example: 'S130U x 0.5'
+licenceId:
+  description: "Internal ID (GUID) allocated by the CM when creating a licence."
+  type: string
+  format: uuid
+  example: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
 licenceNumber:
   description: "The reference of the licence to which a charge / transaction relates"
   type: string

--- a/openapi/schema/parameters.yml
+++ b/openapi/schema/parameters.yml
@@ -61,6 +61,20 @@ financialYear:
   description: "The financial year (1 April to 31 March) within which the charge period of a transaction falls"
   schema:
     $ref: 'fields.yml#/financialYear'
+invoiceId:
+  name: invoiceId
+  in: path
+  required: true
+  description: "Internal ID (GUID) allocated by the CM when creating an invoice."
+  schema:
+    $ref: 'fields.yml#/invoiceId'
+licenceId:
+  name: licenceId
+  in: path
+  required: true
+  description: "Internal ID (GUID) allocated by the CM when creating a licence."
+  schema:
+    $ref: 'fields.yml#/licenceId'
 licenceNumber:
   name: licenceNumber
   in: query

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -94,6 +94,12 @@ paths:
   '/v2/{regime}/calculate-charge':
     $ref: 'paths/v2/calculate_charge/calculate_charge.yml'
 
+  '/v2/{regime}/invoices/{invoiceId}':
+    $ref: 'paths/v2/invoices/invoice.yml'
+
+  '/v2/{regime}/licences/{licenceId}':
+    $ref: 'paths/v2/licences/licence.yml'
+
 security:
   - OAuth2: []
 

--- a/openapi/version_2/paths/v2/invoices/invoice.yml
+++ b/openapi/version_2/paths/v2/invoices/invoice.yml
@@ -1,0 +1,55 @@
+get:
+  operationId: ViewInvoice
+  description: "Request to view details of an invoice."
+  tags:
+    - suggested
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+    - $ref: '../../../../schema/parameters.yml#/invoiceId'
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          example:
+            invoice:
+              id: 'fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3'
+              billRunId: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
+              customerReference: 'TH230000222'
+              financialYear: 2018
+              creditLineCount: 0
+              creditLineValue: 0
+              debitLineCount: 2
+              debitLineValue: 4186
+              zeroValueLineCount: 1
+              newLicenceCount: 0
+              netTotal: 4186
+              licences:
+                - id: '559943dd-8d08-4c95-9600-9c6c7d08d0d8'
+                  creditLineCount: 0
+                  creditLineValue: 0
+                  debitLineCount: 2
+                  debitLineValue: 4186
+                  zeroValueLineCount: 0
+                  newLicenceCount: 0
+                  netTotal: 4186
+                - id: 'b297f240-7a32-444c-a2c4-add07869760f'
+                  creditLineCount: 0
+                  creditLineValue: 0
+                  debitLineCount: 0
+                  debitLineValue: 0
+                  zeroValueLineCount: 1
+                  newLicenceCount: 0
+                  netTotal: 0
+
+delete:
+  operationId: DeleteInvoice
+  description: "Delete the specified invoice and all linked licences and transactions. As part of the deletion the linked bill run will be updated."
+  tags:
+    - suggested
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+    - $ref: '../../../../schema/parameters.yml#/invoiceId'
+  responses:
+    '204':
+      description: "Success"

--- a/openapi/version_2/paths/v2/licences/licence.yml
+++ b/openapi/version_2/paths/v2/licences/licence.yml
@@ -1,0 +1,50 @@
+get:
+  operationId: ViewLicence
+  description: "Request to view details of a licence."
+  tags:
+    - suggested
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+    - $ref: '../../../../schema/parameters.yml#/licenceId'
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          example:
+            licence:
+              id: 'fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3'
+              billRunId: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
+              invoiceId: '559943dd-8d08-4c95-9600-9c6c7d08d0d8'
+              creditLineCount: 0
+              creditLineValue: 0
+              debitLineCount: 2
+              debitLineValue: 4186
+              zeroValueLineCount: 1
+              newLicenceCount: 3
+              netTotal: 4186
+              transactions:
+                - id: 'fe36eccb-4d58-4cb0-8062-01f7c2b886c2'
+                  region: 'A'
+                  credit: false
+                  chargeValue: 2093
+                - id: '08a74e38-3652-44b9-8459-c364d3a3e524'
+                  region: 'A'
+                  credit: false
+                  chargeValue: 2093
+                - id: '9b1cc7c7-4b19-42cc-8d17-90f121edebbb'
+                  region: 'A'
+                  credit: false
+                  chargeValue: 0
+
+delete:
+  operationId: DeleteLicence
+  description: "Delete the specified licence and all linked transactions. As part of the deletion the linked invoice and bill run will also be updated."
+  tags:
+    - suggested
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+    - $ref: '../../../../schema/parameters.yml#/licenceId'
+  responses:
+    '204':
+      description: "Success"


### PR DESCRIPTION
As part of Version 2 of the API invoices and licences will be actual records in the DB with links to the relevant bill runs and transactions. This is all part of the changes we are making to fix the performance issues in the API.

Because of this it means we can add endpoint dedicated to there deletion that work based on ID rather than as a query param. The benefit to us is

- We can build the endpoint to be specific to the task, for example, deleting an invoice and all the work needed to update the bill run and its summary details
- We can be better assured we are deleting the right thing as the client system has provided the IDof the record, rather than just a reference

Exactly where these endpoints will sit is still unknown. For example, should they also sit under `../bill-runs/` or should we look to have a `/{regime}/invoices` path? So this changes adds them under the `suggested` tag for now.