### PR TITLE
Add bill run status endpoint to v2 spec

### DIFF
--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -79,16 +79,19 @@ paths:
   '/v2/{regime}/bill-runs':
     $ref: 'paths/v2/billruns/bill_runs.yml'
 
-  '/v2/{regime}/billruns/{billrunId}':
+  '/v2/{regime}/billruns/{billRunId}':
     $ref: 'paths/v2/billruns/bill_run.yml'
 
-  '/v2/{regime}/bill-runs/{billrunId}/generate':
+  '/v2/{regime}/billruns/{billRunId}/status':
+    $ref: 'paths/v2/billruns/bill_run_status.yml'
+
+  '/v2/{regime}/bill-runs/{billRunId}/generate':
     $ref: 'paths/v2/billruns/bill_run_generate.yml'
 
-  '/v2/{regime}/billruns/{billrunId}/send':
+  '/v2/{regime}/billruns/{billRunId}/send':
     $ref: 'paths/v2/billruns/bill_run_send.yml'
 
-  '/v2/{regime}/bill-runs/{billrunId}/transactions':
+  '/v2/{regime}/bill-runs/{billRunId}/transactions':
     $ref: 'paths/v2/billruns/transactions/bill_run_transactions.yml'
 
   '/v2/{regime}/calculate-charge':

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -79,19 +79,19 @@ paths:
   '/v2/{regime}/bill-runs':
     $ref: 'paths/v2/billruns/bill_runs.yml'
 
-  '/v2/{regime}/billruns/{billRunId}':
+  '/v2/{regime}/billruns/{billrunId}':
     $ref: 'paths/v2/billruns/bill_run.yml'
 
-  '/v2/{regime}/billruns/{billRunId}/status':
+  '/v2/{regime}/billruns/{billrunId}/status':
     $ref: 'paths/v2/billruns/bill_run_status.yml'
 
-  '/v2/{regime}/bill-runs/{billRunId}/generate':
+  '/v2/{regime}/bill-runs/{billrunId}/generate':
     $ref: 'paths/v2/billruns/bill_run_generate.yml'
 
-  '/v2/{regime}/billruns/{billRunId}/send':
+  '/v2/{regime}/billruns/{billrunId}/send':
     $ref: 'paths/v2/billruns/bill_run_send.yml'
 
-  '/v2/{regime}/bill-runs/{billRunId}/transactions':
+  '/v2/{regime}/bill-runs/{billrunId}/transactions':
     $ref: 'paths/v2/billruns/transactions/bill_run_transactions.yml'
 
   '/v2/{regime}/calculate-charge':

--- a/openapi/version_2/paths/v2/billruns/bill_run_status.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_status.yml
@@ -1,0 +1,26 @@
+get:
+  operationId: ViewBillRunStatus
+  description: "Request to view the status of a single bill run based on the bill run ID. It is intended to help client systems quickly determine if a bill run is ready to be viewed after a `/generate` request and reduce the load on the API."
+  tags:
+    - billrun
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+    - $ref: '../../../../schema/parameters.yml#/billrunId'
+  responses:
+    '200':
+      description: "Success"
+      content:
+        application/json:
+          examples:
+            '01 Just created':
+              value:
+                status: 'initialised'
+            '02 Transactions added':
+              value:
+                status: 'initialised'
+            '03 Generating summary':
+              value:
+                status: 'generating'
+            '04 Summary generated':
+              value:
+                status: 'summarised'

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -749,6 +749,57 @@ paths:
                           licenceNumber: FOOO/BARRR/306
                         - id: 77502697-e274-491a-bd6d-84ec557b0485
                           licenceNumber: FOOO/BARRR/307
+  "/v2/{regime}/billruns/{billrunId}/status":
+    get:
+      operationId: ViewBillRunStatus
+      description: Request to view the status of a single bill run based on the bill
+        run ID. It is intended to help client systems quickly determine if a bill
+        run is ready to be viewed after a `/generate` request and reduce the load
+        on the API.
+      tags:
+      - billrun
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              examples:
+                01 Just created:
+                  value:
+                    status: initialised
+                02 Transactions added:
+                  value:
+                    status: initialised
+                03 Generating summary:
+                  value:
+                    status: generating
+                04 Summary generated:
+                  value:
+                    status: summarised
   "/v2/{regime}/bill-runs/{billrunId}/generate":
     patch:
       operationId: GenerateBillRun


### PR DESCRIPTION
The workflow around bill runs is

- create bill run
- add transactions
- generate summary
- keep checking bill run status until summary is complete
- get bill run view

At the moment the only endpoint to check the status of the bill run is the view bill run. We are intending to remove the transaction detail to make it more performant. But we'll still have to collate all invoice and licence detail to provide a full response.

This seems overkill and will impact performance if all a client system actually needs to know is if the status has gone from `generating` to `summarised`. So this change adds details of a new endpoint it is likely we'll add to V2 that can be used to just check the status of a bill run.