### PR TITLE
Add missing properties to v2 bill run response

### DIFF
--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -63,6 +63,7 @@ get:
                       zeroValueLineCount: 0
                       netTotal: 2500
                       deminimis: false
+                      netZeroValue: false
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -99,6 +100,7 @@ get:
                       zeroValueLineCount: 0
                       netTotal: 2500
                       deminimis: false
+                      netZeroValue: false
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -135,6 +137,7 @@ get:
                       zeroValueLineCount: 0
                       netTotal: 2500
                       deminimis: false
+                      netZeroValue: false
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'

--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -64,6 +64,8 @@ get:
                       netTotal: 2500
                       deminimis: false
                       netZeroValue: false
+                      transactionType: ''
+                      transactionReference: ''
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -101,6 +103,8 @@ get:
                       netTotal: 2500
                       deminimis: false
                       netZeroValue: false
+                      transactionType: ''
+                      transactionReference: ''
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -138,6 +142,8 @@ get:
                       netTotal: 2500
                       deminimis: false
                       netZeroValue: false
+                      transactionType: ''
+                      transactionReference: ''
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'

--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -53,6 +53,7 @@ get:
                   netTotal: 2500
                   invoices:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
+                      summarised: false
                       customerReference: 'TH150000020'
                       financialYear: 2019
                       creditLineCount: 0
@@ -88,6 +89,7 @@ get:
                   netTotal: 2500
                   invoices:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
+                      summarised: false
                       customerReference: 'TH150000020'
                       financialYear: 2019
                       creditLineCount: 0
@@ -123,6 +125,7 @@ get:
                   netTotal: 2500
                   invoices:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
+                      summarised: true
                       customerReference: 'TH150000020'
                       financialYear: 2019
                       creditLineCount: 0

--- a/openapi/version_2/paths/v2/invoices/invoice.yml
+++ b/openapi/version_2/paths/v2/invoices/invoice.yml
@@ -15,6 +15,7 @@ get:
             invoice:
               id: 'fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3'
               billRunId: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
+              summarised: true
               customerReference: 'TH230000222'
               financialYear: 2018
               creditLineCount: 0
@@ -24,6 +25,10 @@ get:
               zeroValueLineCount: 1
               newLicenceCount: 0
               netTotal: 4186
+              deminimis: false
+              netZeroValue: false
+              transactionType: ''
+              transactionReference: ''
               licences:
                 - id: '559943dd-8d08-4c95-9600-9c6c7d08d0d8'
                   creditLineCount: 0

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -665,6 +665,7 @@ paths:
                       netTotal: 2500
                       invoices:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                        summarised: false
                         customerReference: TH150000020
                         financialYear: 2019
                         creditLineCount: 0
@@ -674,6 +675,9 @@ paths:
                         zeroValueLineCount: 0
                         netTotal: 2500
                         deminimis: false
+                        netZeroValue: false
+                        transactionType: ''
+                        transactionReference: ''
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -700,6 +704,7 @@ paths:
                       netTotal: 2500
                       invoices:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                        summarised: false
                         customerReference: TH150000020
                         financialYear: 2019
                         creditLineCount: 0
@@ -709,6 +714,9 @@ paths:
                         zeroValueLineCount: 0
                         netTotal: 2500
                         deminimis: false
+                        netZeroValue: false
+                        transactionType: ''
+                        transactionReference: ''
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -735,6 +743,7 @@ paths:
                       netTotal: 2500
                       invoices:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                        summarised: true
                         customerReference: TH150000020
                         financialYear: 2019
                         creditLineCount: 0
@@ -744,6 +753,9 @@ paths:
                         zeroValueLineCount: 0
                         netTotal: 2500
                         deminimis: false
+                        netZeroValue: false
+                        transactionType: ''
+                        transactionReference: ''
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -1486,6 +1498,7 @@ paths:
                 invoice:
                   id: fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3
                   billRunId: fd2ab097-3097-42bd-849e-046aa250a0d0
+                  summarised: true
                   customerReference: TH230000222
                   financialYear: 2018
                   creditLineCount: 0
@@ -1495,6 +1508,10 @@ paths:
                   zeroValueLineCount: 1
                   newLicenceCount: 0
                   netTotal: 4186
+                  deminimis: false
+                  netZeroValue: false
+                  transactionType: ''
+                  transactionReference: ''
                   licences:
                   - id: 559943dd-8d08-4c95-9600-9c6c7d08d0d8
                     creditLineCount: 0


### PR DESCRIPTION
Thoughat this time we are not trying to define the final view bill run response (we've not built it yet!) we also know that the conversation could be diverted if people construe it in that way. So this change adds some properties to the view bill run response that exist in V1, and which we fully expect to include in V2, but which we haven't added to our examples in the spec.