### PR TITLE
Add transaction file ref to View bill run response

### DIFF
--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -31,6 +31,7 @@ get:
                   debitLineValue: 0
                   zeroValueLineCount: 0
                   netTotal: 0
+                  transactionFileReference: ''
                   invoices: []
             '02 Transactions added':
               value:
@@ -51,6 +52,7 @@ get:
                   debitLineValue: 2500
                   zeroValueLineCount: 0
                   netTotal: 2500
+                  transactionFileReference: ''
                   invoices:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
                       summarised: false
@@ -90,6 +92,7 @@ get:
                   debitLineValue: 2500
                   zeroValueLineCount: 0
                   netTotal: 2500
+                  transactionFileReference: ''
                   invoices:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
                       summarised: false
@@ -129,6 +132,7 @@ get:
                   debitLineValue: 2500
                   zeroValueLineCount: 0
                   netTotal: 2500
+                  transactionFileReference: ''
                   invoices:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
                       summarised: true

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -643,6 +643,7 @@ paths:
                       debitLineValue: 0
                       zeroValueLineCount: 0
                       netTotal: 0
+                      transactionFileReference: ''
                       invoices: []
                 02 Transactions added:
                   value:
@@ -663,6 +664,7 @@ paths:
                       debitLineValue: 2500
                       zeroValueLineCount: 0
                       netTotal: 2500
+                      transactionFileReference: ''
                       invoices:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
                         summarised: false
@@ -702,6 +704,7 @@ paths:
                       debitLineValue: 2500
                       zeroValueLineCount: 0
                       netTotal: 2500
+                      transactionFileReference: ''
                       invoices:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
                         summarised: false
@@ -741,6 +744,7 @@ paths:
                       debitLineValue: 2500
                       zeroValueLineCount: 0
                       netTotal: 2500
+                      transactionFileReference: ''
                       invoices:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
                         summarised: true


### PR DESCRIPTION
`transactionFileReference` is something that gets populated when the `/send` request is made. But as part of our intent to keep the structure the same for the view bill run it will make things clearer if we include it in our examples, even though it will be empty.

So this updates the Version 2 spec to include it in the examples.