### PR TITLE
Add notes about docker hub integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,14 @@ ___*
 
 .idea
 
+# Docker Compose environment files https://docs.docker.com/compose/env-file/
+# Ignore the .env file as this may contain actual credentials. The .env.example
+# file gets committed which acts as documentation on what environment
+# variables will need to be set up
+.env
+.env.local
+.env_docker
+
 # Ignore generated OpenAPI unified schema files
 # We generate these files as part of publishing the spec to SwaggerHub. But they
 # are not something we need to keep track of in source control.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This acts as a repo of guides and documents specific to the team, plus it's wher
 ## Contents
 
 - [Databases](/databases/README.md)
+- [Docker Hub](/dockerhub/README.md)
 - [Guide to ssh](ssh.md)
 - [OpenAPI documentation](/openapi/README.md)
 - [Postman guide](/postman/README.md)

--- a/dockerhub/README.md
+++ b/dockerhub/README.md
@@ -1,0 +1,16 @@
+# Docker Hub
+
+To allow users of the API to work with it locally and not rely on a connection to our AWS `INTEGRATION` environment we produce Docker container images.
+
+> A Docker image is a read-only template that contains a set of instructions for creating a container that can run on the Docker platform. It provides a convenient way to package up applications and preconfigured server environments, which you can use for your own private use or share publicly with other Docker users.
+>
+> [A Beginner’s Guide to Understanding and Building Docker Images](https://jfrog.com/knowledge-base/a-beginners-guide-to-understanding-and-building-docker-images/)
+
+We make these accessible on [Docker Hub](https://hub.docker.com/).
+
+- Images for [Version 1 of the API](https://github.com/defra/charging-module-api) are at [environmentagency/charging-module-api](https://hub.docker.com/r/environmentagency/charging-module-api)
+- Images for [Version 2 of the API](https://github.com/defra/sroc-charging-module-api) are at [environmentagency/sroc-charging-module-api](https://hub.docker.com/r/environmentagency/sroc-charging-module-api)
+
+Along with the images we provide instructions on how to get up and running with them using [Docker Compose](https://docs.docker.com/compose/) and a [makefile](https://en.wikipedia.org/wiki/Makefile).
+
+This folder is where we store a copy of the instructions and example files for each version.

--- a/dockerhub/README.md
+++ b/dockerhub/README.md
@@ -14,3 +14,8 @@ We make these accessible on [Docker Hub](https://hub.docker.com/).
 Along with the images we provide instructions on how to get up and running with them using [Docker Compose](https://docs.docker.com/compose/) and a [makefile](https://en.wikipedia.org/wiki/Makefile).
 
 This folder is where we store a copy of the instructions and example files for each version.
+
+## Instruction and example files
+
+- [Version 1 of the API](/version_1)
+- [Version 2 of the API](/version_2)

--- a/dockerhub/README.md
+++ b/dockerhub/README.md
@@ -19,3 +19,13 @@ This folder is where we store a copy of the instructions and example files for e
 
 - [Version 1 of the API](/version_1)
 - [Version 2 of the API](/version_2)
+
+### README issue for Version 2
+
+For version 2 we enabled the [auto build feature](https://docs.docker.com/docker-hub/builds/) of Docker Hub after first linking it to the [GitHub repo](https://hub.docker.com/r/environmentagency/charging-module-api).
+
+This has proven to be very helpful. Not only can users of the API pull the latest build down as an image, as we tag (version) changes in the project Docker Hub automatically builds a matching image.
+
+The downside is that each time an automated build runs, Docker Hub overwrites its README with the one in the linked GitHub repo. This was originally [raised as an issue 5 years ago](https://github.com/docker/hub-feedback/issues/325) but as yet nothing has been done about it.
+
+This was actually the main driver for putting these files in this project; if we hadn't they really wouldn't have had a home anywhere else.

--- a/dockerhub/version_1/.env.example
+++ b/dockerhub/version_1/.env.example
@@ -1,0 +1,45 @@
+# Default host and port details
+NODE_ENV=development
+PORT=3000
+SERVICE_URL=http://localhost:3004
+
+# Api config
+BILL_RUN_SUMMARY_TIMEOUT=3000
+
+# Postgres values
+PGUSER=charge
+PGPASSWORD=password
+PGHOST=db
+PGPORT=5432
+PGDATABASE=chargedb
+
+# Airbrake to Errbit error reporting
+AIRBRAKE_HOST=https://my-errbit-instance.com
+AIRBRAKE_KEY=longvaluefullofnumbersandlettersinlowercase
+
+# AWS S3 credentials
+UPLOAD_ACCESS_KEY=SHORTVALUEFULLOFNUMBERSANDLETTERSINUPPERCASE
+UPLOAD_SECRET_KEY=longvaluefullofnumbersandlettersinlowercase
+UPLOAD_BUCKET=my-upload-bucket
+
+ARCHIVE_ACCESS_KEY=SHORTVALUEFULLOFNUMBERSANDLETTERSINUPPERCASE
+ARCHIVE_SECRET_KEY=longvaluefullofnumbersandlettersinlowercase
+ARCHIVE_BUCKET=my-archive-bucket
+
+# Decision service
+DECISION_SERVICE_URL=https://my-decision-service-instance.com
+DECISION_SERVICE_USER=charging
+DECISION_SERVICE_PASSWORD=password12345
+
+# Admin client ID
+ADMIN_CLIENT_ID=shortvaluefullofnumbersandlettersinlowercase
+
+# RULES
+CFD_APP=cfd_RuleApp
+CFD_RULESET=cfd_RuleSet
+WML_APP=wml_RuleApp
+WML_RULESET=wml_RuleSet
+PAS_APP=pas_RuleApp
+PAS_RULESET=pas_RuleSet
+WRLS_APP=wrls_RuleApp
+WRLS_RULESET=wrls_RuleSet

--- a/dockerhub/version_1/README.md
+++ b/dockerhub/version_1/README.md
@@ -1,0 +1,91 @@
+# Charging module API
+
+The API provides an interface for calculating charges, creating and queuing transactions, and generating transaction and customer files used to produce Environment Agency invoices.
+
+The images are built from [charging-module-api](https://github.com/defra/charging-module-api) each time we tag and generate a release version. They are provided here to allow teams wishing to develop clients for the API to run it locally.
+
+You can find more details about the SROC delivery team which maintain the API at <https://github.com/DEFRA/sroc-service-team>.
+
+## How to use this image
+
+The following is an example [docker-compose](https://docs.docker.com/compose/) you can use to bring up a working environment
+
+```yml
+version: '3.8'
+
+services:
+  db:
+    image: postgres:10-alpine
+    volumes:
+      - cha_api_db_volume:/var/lib/postgresql/data
+    ports:
+      - "54321:5432"
+    environment:
+      POSTGRES_USER: "${PGUSER}"
+      POSTGRES_PASSWORD: "${PGPASSWORD}"
+      POSTGRES_DB: "${PGDATABASE}"
+
+  app:
+    image: environmentagency/charging-module-api:latest
+    ports:
+      - "3005:3000"
+    env_file:
+      - .env
+    depends_on:
+      - db
+
+volumes:
+  cha_api_db_volume:
+```
+
+You will need to create a [.env file](https://docs.docker.com/compose/env-file/) with the correct values before you first attempt to build the environment. The project's repo has an [example](https://github.com/DEFRA/charging-module-api/blob/main/.env.example). But you will need to contact the SROC delivery team to obtain the necessary credentials you'll need to actually make it work.
+
+> ***NEVER*** commit the `.env` to source control. The credentials the SROC delivery team provide _must_ remain secret.
+
+With the `.env` file in place, you can tell compose to grab the images and start the environment for the first time with `docker-compose up`.
+
+## Helper file
+
+It's common to see a script file with docker environments to provide quick access to common commands. To get folks started here is an example [makefile](https://en.wikipedia.org/wiki/Makefile) we have put together.
+
+```makefile
+# Usage:
+# make          # same as up
+# make up       # pull the images (if not done so already) and start the containers
+# make down     # will stop (if not already stopped) all running containers and remove them
+# make clean    # same as clean but will also remove any custom images and the volumes we've created
+# make open     # open a shell on the running API container
+
+.DEFAULT_GOAL := up
+
+up:
+	docker-compose up
+
+down:
+	docker-compose down
+
+clean:
+	docker-compose down --rmi local -v
+
+open:
+	docker-compose exec app /bin/sh
+
+```
+
+To use drop it in the same folder as your `docker-compose.yml` and then from your terminal call `make up` (or whatever command you need).
+
+## Known issues
+
+We have noted the app will often fail on the first `docker-compose up`. This seems to be caused when it attempts to run database migrations for the first time. Currently, the workaround is to stop the containers, count to 5, then call `docker-compose up` (or `make up`) again. We're sorry for any confusion this causes 😢
+
+## Further information
+
+You can find documentation about the API on [SwaggerHub](https://app.swaggerhub.com/apis-docs/sro/charging-module_api/v0.3.0). We generate documentation for each version of the API. For example
+
+- `v0.3.0` - <https://app.swaggerhub.com/apis-docs/sro/charging-module_api/v0.3.0>
+- `v0.2.0` - <https://app.swaggerhub.com/apis-docs/sro/charging-module_api/v0.2.0>
+- `v0.1.0` - <https://app.swaggerhub.com/apis-docs/sro/charging-module_api/v0.1.0>
+
+To see what the API will look like for the next release check out the [draft version](https://app.swaggerhub.com/apis-docs/sro/charging-module_api/draft)
+
+We have also [provided guidance](https://github.com/DEFRA/sroc-service-team/tree/main/postman) on how you can set up [Postman](https://www.postman.com/product/api-client/) to interact with the API.

--- a/dockerhub/version_1/docker-compose.yml
+++ b/dockerhub/version_1/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:10-alpine
+    volumes:
+      - cha_api_db_volume:/var/lib/postgresql/data
+    ports:
+      - "54321:5432"
+    environment:
+      POSTGRES_USER: "${PGUSER}"
+      POSTGRES_PASSWORD: "${PGPASSWORD}"
+      POSTGRES_DB: "${PGDATABASE}"
+
+  app:
+    image: environmentagency/charging-module-api:latest
+    ports:
+      - "3005:3000"
+    env_file:
+      - .env
+    depends_on:
+      - db
+
+volumes:
+  cha_api_db_volume:

--- a/dockerhub/version_1/makefile
+++ b/dockerhub/version_1/makefile
@@ -1,0 +1,20 @@
+# Usage:
+# make          # same as up
+# make up       # pull the images (if not done so already) and start the containers
+# make down     # will stop (if not already stopped) all running containers and remove them
+# make clean    # same as clean but will also remove any custom images and the volumes we've created
+# make open     # open a shell on the running API container
+
+.DEFAULT_GOAL := up
+
+up:
+	docker-compose up
+
+down:
+	docker-compose down
+
+clean:
+	docker-compose down --rmi local -v
+
+open:
+	docker-compose exec app /bin/sh

--- a/dockerhub/version_2/.env.example
+++ b/dockerhub/version_2/.env.example
@@ -1,0 +1,44 @@
+# Ensure timezone is set to UTC
+TZ=UTC
+
+# Airbrake config
+AIRBRAKE_HOST=https://my-errbit-instance.com
+AIRBRAKE_KEY=longvaluefullofnumbersandlettersinlowercase
+
+# Authentication config
+ENVIRONMENT=int
+ADMIN_CLIENT_ID=cognitoclientidforadminuser
+SYSTEM_CLIENT_ID=cognitoclientidforsystemuser
+IGNORE_JWT_EXPIRATION=true
+
+# Database config
+POSTGRES_USER=charge
+POSTGRES_PASSWORD=password
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+POSTGRES_DB=sroc_charge
+
+# Server config
+PORT=3000
+# Only needed if you are required to go through a proxy server for access to the internet
+HTTP_PROXY='http://proxy:3128'
+
+# Rules service
+RULES_SERVICE_URL=https://rules.service
+RULES_SERVICE_USER=username
+RULES_SERVICE_PASSWORD=password
+RULES_SERVICE_TIMEOUT=5000
+CFD_APP=TCM_WaterQuality_RuleApp
+CFD_RULESET=WaterQuality_RuleSet
+WML_APP=TCM_WasteFacilities_RuleApp
+WML_RULESET=WasteFacilities_RuleSet
+PAS_APP=TCM_Installations_RuleApp
+PAS_RULESET=Installations_RuleSet
+WRLS_APP=TEST_WRLS_Pre_SRoC_RuleApp
+WRLS_RULESET=WRLS_Pre_SRoC_RuleSet
+WRLS_SROC_APP=TEST_WRLS_SRoC_RuleApp
+WRLS_SROC_RULESET=WRLS_SRoC_RuleSet
+
+# Minimum date for Sroc charge period - defaults to 01-APR-2021 if not present
+# We can specify an earlier date while waiting for the rules service 2021 endpoint to be created
+SROC_MINIMUM_DATE='01-APR-2020'

--- a/dockerhub/version_2/README.md
+++ b/dockerhub/version_2/README.md
@@ -1,0 +1,120 @@
+# SROC Charging module API
+
+> A work in progress version 2 of the original [Charging Module API](https://github.com/DEFRA/charging-module-api)
+
+This API provides an interface for calculating charges, queuing transactions and generating transaction files used to produce invoices.
+
+The images are built from [sroc-charging-module-api](https://github.com/defra/sroc-charging-module-api) automatically. They are provided here to allow teams wishing to develop clients for the API to run it locally.
+
+You can find more details about the SROC delivery team which maintain the API at <https://github.com/DEFRA/sroc-service-team>.
+
+## How to use this image
+
+The following is an example [docker-compose](https://docs.docker.com/compose/) you can use to bring up an environment
+
+```yml
+version: '3.8'
+
+services:
+  db:
+    image: postgres:12-alpine
+    volumes:
+      - cma_api_db_volume:/var/lib/postgresql/data
+    ports:
+      - "54322:5432"
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_DB: "${POSTGRES_DB}"
+
+  app:
+    image: environmentagency/sroc-charging-module-api:latest
+    ports:
+      - "3006:3000"
+    env_file:
+      - .env
+    depends_on:
+      - db
+
+volumes:
+  cma_api_db_volume:
+```
+
+You will need to create a [.env file](https://docs.docker.com/compose/env-file/) with the correct values before you first attempt to build the environment. The project's repo has an [example](https://github.com/DEFRA/sroc-charging-module-api/blob/main/.env.example). But you will need to contact the SROC delivery team to obtain the necessary credentials you'll need to actually make it work.
+
+> ***NEVER*** commit the `.env` to source control. The credentials the SROC delivery team provide _must_ remain secret.
+
+With the `.env` file in place, you can tell compose to grab the images and start the environment for the first time with `docker-compose up`.
+
+## Helper file
+
+It's common to see a script file with docker environments to provide quick access to common commands. To get folks started here is an example [makefile](https://en.wikipedia.org/wiki/Makefile) we have put together.
+
+```makefile
+# Usage:
+# make          # same as up
+# make up       # pull the images (if not done so already) and start the containers
+# make down     # will stop (if not already stopped) all running containers and remove them
+# make clean    # same as clean but will also remove any custom images and the volumes we've created
+# make open     # open a shell on the running API container
+# make migrate  # run latest database migrations. You'll need to do this each time you pull a new image down
+# make seed     # run latest database seeds. You may need to do this after pulling a new image down
+# make run      # start a new container and open an interactive shell to it
+
+.DEFAULT_GOAL := up
+
+up:
+	docker-compose up
+
+down:
+	docker-compose down
+
+clean:
+	docker-compose down --rmi local -v
+
+open:
+	docker-compose exec app /bin/sh
+
+migrate:
+	docker-compose exec app npm run migratedb
+
+seed:
+	docker-compose exec app npm run seeddb
+
+run:
+	docker run -it --env-file .env environmentagency/sroc-charging-module-api:latest /bin/sh
+
+```
+
+To use drop it in the same folder as your `docker-compose.yml` and then from your terminal call `make up` (or whatever command you need).
+
+> make ❤️'s tabs! The actions [must be indented with a tab](https://stackoverflow.com/a/16945143/6117745). Spaces won't cut it. Make sure you don't lose the tabs when copying and pasting.
+
+## Getting started
+
+To get everything up, assuming you have created the `docker-compose.yml` and `makefile`, run the following commands in this order
+
+1. `make up` _You are probably going to want to open another terminal for the remaining commands_
+1. `make migrate`
+1. `make seed`
+
+The environment should now be ready to use.
+
+## Authentication
+
+With the `.env` provided by the SROC team, and having run `make seed` the authorised systems (users) you'll need to access the API will automatically have been created.
+
+We encourage all users of this API to check out our [JSON Web Keys readme](https://github.com/DEFRA/sroc-charging-module-api/tree/main/keys) which goes into detail about how requests are authenticated.
+
+In short, all requests to the API must have a bearer token
+
+- that is properly signed
+- that contains a `client_id` which matches one saved against an `authorised_system` in the database
+
+We do have a config setting that disables checking whether a token is expired. If this is not disabled you also need to ensure the bearer token has not expired.
+
+## Further information
+
+You can find _in progress_ documentation about the API on [SwaggerHub](https://app.swaggerhub.com/apis-docs/sro/sroc-charging-module-api/draft). This version of the API is a _work in progress_. As such the documentation remains in `draft`, though we continually update it to reflect new features and changes made to the API.
+
+We have also [provided guidance](https://github.com/DEFRA/sroc-service-team/tree/main/postman) on how you can set up [Postman](https://www.postman.com/product/api-client/) to interact with an API.

--- a/dockerhub/version_2/docker-compose.yml
+++ b/dockerhub/version_2/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:12-alpine
+    volumes:
+      - cma_api_db_volume:/var/lib/postgresql/data
+    ports:
+      - "54322:5432"
+    environment:
+      POSTGRES_USER: "${POSTGRES_USER}"
+      POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
+      POSTGRES_DB: "${POSTGRES_DB}"
+
+  app:
+    image: environmentagency/sroc-charging-module-api:latest
+    ports:
+      - "3006:3000"
+    env_file:
+      - .env
+    depends_on:
+      - db
+
+volumes:
+  cma_api_db_volume:

--- a/dockerhub/version_2/makefile
+++ b/dockerhub/version_2/makefile
@@ -1,0 +1,32 @@
+# Usage:
+# make          # same as up
+# make up       # pull the images (if not done so already) and start the containers
+# make down     # will stop (if not already stopped) all running containers and remove them
+# make clean    # same as clean but will also remove any custom images and the volumes we've created
+# make open     # open a shell on the running API container
+# make migrate  # run latest database migrations. You'll need to do this each time you pull a new image down
+# make seed     # run latest database seeds. You may need to do this after pulling a new image down
+# make run      # start a new container and open an interactive shell to it
+
+.DEFAULT_GOAL := up
+
+up:
+	docker-compose up
+
+down:
+	docker-compose down
+
+clean:
+	docker-compose down --rmi local -v
+
+open:
+	docker-compose exec app /bin/sh
+
+migrate:
+	docker-compose exec app npm run migratedb
+
+seed:
+	docker-compose exec app npm run seeddb
+
+run:
+	docker run -it --env-file .env environmentagency/sroc-charging-module-api:latest /bin/sh


### PR DESCRIPTION
https://trello.com/c/jHORNdnQ

We have now made [version 2](https://github.com/defra/sroc-charging-module-api) available as a docker image in [Docker Hub](https://hub.docker.com/r/environmentagency/sroc-charging-module-api). As part of that, we have produced a guide on how to get started, along with an example `docker-compose.yml` and `makefile`.

Normally, this information would all be added to the README on docker hub. But we have also enabled automated builds. This means you can always grab whatever is on `main` as a docker image plus whenever we add a tag docker hub automatically builds a matching image. Sweet!

The downside is the standard behaviour of an automated build is to [overwrite the README in docker hub with the one from the source repo](https://github.com/docker/hub-feedback/issues/325)! 😩🤦

So, at some point, we'll want to update the API read me to make sense in both contexts. But for now, it also means we need a place to store details about the integration plus the guide and example files we have produced.

This change covers adding all that here.