### PR TITLE
Correct V2 view bill run API examples

### DIFF
--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -28,7 +28,7 @@ get:
                   creditLineValue: 0
                   debitLineCount: 0
                   debitLineValue: 0
-                  zeroValueLineCount: 0
+                  zeroLineCount: 0
                   netTotal: 0
                   transactionFileReference: ''
                   invoices: []
@@ -48,7 +48,7 @@ get:
                   creditLineValue: 0
                   debitLineCount: 2
                   debitLineValue: 2500
-                  zeroValueLineCount: 0
+                  zeroLineCount: 0
                   netTotal: 2500
                   transactionFileReference: ''
                   invoices:
@@ -59,7 +59,7 @@ get:
                       creditLineValue: 0
                       debitLineCount: 2
                       debitLineValue: 2500
-                      zeroValueLineCount: 0
+                      zeroLineCount: 0
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
@@ -85,7 +85,7 @@ get:
                   creditLineValue: 0
                   debitLineCount: 2
                   debitLineValue: 2500
-                  zeroValueLineCount: 0
+                  zeroLineCount: 0
                   netTotal: 2500
                   transactionFileReference: ''
                   invoices:
@@ -96,7 +96,7 @@ get:
                       creditLineValue: 0
                       debitLineCount: 2
                       debitLineValue: 2500
-                      zeroValueLineCount: 0
+                      zeroLineCount: 0
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
@@ -122,7 +122,7 @@ get:
                   creditLineValue: 0
                   debitLineCount: 2
                   debitLineValue: 2500
-                  zeroValueLineCount: 0
+                  zeroLineCount: 0
                   netTotal: 2500
                   transactionFileReference: ''
                   invoices:
@@ -133,7 +133,7 @@ get:
                       creditLineValue: 0
                       debitLineCount: 2
                       debitLineValue: 2500
-                      zeroValueLineCount: 0
+                      zeroLineCount: 0
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false

--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -19,7 +19,6 @@ get:
                   billRunNumber: 10001
                   region: 'W'
                   status: 'initialised'
-                  approvedForBilling: false
                   creditNoteCount: 0
                   creditNoteValue: 0
                   invoiceCount: 0
@@ -39,7 +38,6 @@ get:
                   billRunNumber: 10001
                   region: 'W'
                   status: 'initialised'
-                  approvedForBilling: false
                   creditNoteCount: 0
                   creditNoteValue: 0
                   invoiceCount: 0
@@ -76,7 +74,6 @@ get:
                   billRunNumber: 10001
                   region: 'W'
                   status: 'generating'
-                  approvedForBilling: false
                   creditNoteCount: 0
                   creditNoteValue: 0
                   invoiceCount: 0
@@ -113,7 +110,6 @@ get:
                   billRunNumber: 10001
                   region: 'W'
                   status: 'generated'
-                  approvedForBilling: false
                   creditNoteCount: 0
                   creditNoteValue: 0
                   invoiceCount: 1

--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -139,3 +139,39 @@ get:
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
                       netTotal: 2500
+            '05 Approved':
+              value:
+                billRun:
+                  id: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
+                  billRunNumber: 10001
+                  region: 'W'
+                  status: 'approved'
+                  creditNoteCount: 0
+                  creditNoteValue: 0
+                  invoiceCount: 1
+                  invoiceValue: 2500
+                  creditLineCount: 0
+                  creditLineValue: 0
+                  debitLineCount: 2
+                  debitLineValue: 2500
+                  zeroLineCount: 0
+                  netTotal: 2500
+                  transactionFileReference: ''
+                  invoices:
+                    - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
+                      customerReference: 'TH150000020'
+                      financialYear: 2019
+                      creditLineCount: 0
+                      creditLineValue: 0
+                      debitLineCount: 2
+                      debitLineValue: 2500
+                      zeroLineCount: 0
+                      deminimisInvoice: false
+                      zeroValueInvoice: false
+                      minimumChargeInvoice: false
+                      licences:
+                        - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
+                          licenceNumber: 'FOOO/BARRR/306'
+                        - id: '77502697-e274-491a-bd6d-84ec557b0485'
+                          licenceNumber: 'FOOO/BARRR/307'
+                      netTotal: 2500

--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -67,7 +67,7 @@ get:
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
                       netTotal: 2500
-            '03 Generating summary':
+            '03 Generating bill run':
               value:
                 billRun:
                   id: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
@@ -103,7 +103,7 @@ get:
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
                       netTotal: 2500
-            '04 Summary generated':
+            '04 Bill run generated':
               value:
                 billRun:
                   id: 'fd2ab097-3097-42bd-849e-046aa250a0d0'

--- a/openapi/version_2/paths/v2/billruns/bill_run_status.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_status.yml
@@ -18,9 +18,12 @@ get:
             '02 Transactions added':
               value:
                 status: 'initialised'
-            '03 Generating summary':
+            '03 Generating bill run':
               value:
                 status: 'generating'
-            '04 Summary generated':
+            '04 Bill run generated':
               value:
-                status: 'summarised'
+                status: 'generated'
+            '05 Approved':
+              value:
+                status: 'aproved'

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -616,7 +616,6 @@ paths:
                       billRunNumber: 10001
                       region: W
                       status: initialised
-                      approvedForBilling: false
                       creditNoteCount: 0
                       creditNoteValue: 0
                       invoiceCount: 0
@@ -625,7 +624,7 @@ paths:
                       creditLineValue: 0
                       debitLineCount: 0
                       debitLineValue: 0
-                      zeroValueLineCount: 0
+                      zeroLineCount: 0
                       netTotal: 0
                       transactionFileReference: ''
                       invoices: []
@@ -636,7 +635,6 @@ paths:
                       billRunNumber: 10001
                       region: W
                       status: initialised
-                      approvedForBilling: false
                       creditNoteCount: 0
                       creditNoteValue: 0
                       invoiceCount: 0
@@ -645,7 +643,7 @@ paths:
                       creditLineValue: 0
                       debitLineCount: 2
                       debitLineValue: 2500
-                      zeroValueLineCount: 0
+                      zeroLineCount: 0
                       netTotal: 2500
                       transactionFileReference: ''
                       invoices:
@@ -656,7 +654,7 @@ paths:
                         creditLineValue: 0
                         debitLineCount: 2
                         debitLineValue: 2500
-                        zeroValueLineCount: 0
+                        zeroLineCount: 0
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
@@ -666,14 +664,13 @@ paths:
                         - id: 77502697-e274-491a-bd6d-84ec557b0485
                           licenceNumber: FOOO/BARRR/307
                         netTotal: 2500
-                03 Generating summary:
+                03 Generating bill run:
                   value:
                     billRun:
                       id: fd2ab097-3097-42bd-849e-046aa250a0d0
                       billRunNumber: 10001
                       region: W
                       status: generating
-                      approvedForBilling: false
                       creditNoteCount: 0
                       creditNoteValue: 0
                       invoiceCount: 0
@@ -682,7 +679,7 @@ paths:
                       creditLineValue: 0
                       debitLineCount: 2
                       debitLineValue: 2500
-                      zeroValueLineCount: 0
+                      zeroLineCount: 0
                       netTotal: 2500
                       transactionFileReference: ''
                       invoices:
@@ -693,7 +690,7 @@ paths:
                         creditLineValue: 0
                         debitLineCount: 2
                         debitLineValue: 2500
-                        zeroValueLineCount: 0
+                        zeroLineCount: 0
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
@@ -703,14 +700,13 @@ paths:
                         - id: 77502697-e274-491a-bd6d-84ec557b0485
                           licenceNumber: FOOO/BARRR/307
                         netTotal: 2500
-                04 Summary generated:
+                04 Bill run generated:
                   value:
                     billRun:
                       id: fd2ab097-3097-42bd-849e-046aa250a0d0
                       billRunNumber: 10001
                       region: W
                       status: generated
-                      approvedForBilling: false
                       creditNoteCount: 0
                       creditNoteValue: 0
                       invoiceCount: 1
@@ -719,7 +715,7 @@ paths:
                       creditLineValue: 0
                       debitLineCount: 2
                       debitLineValue: 2500
-                      zeroValueLineCount: 0
+                      zeroLineCount: 0
                       netTotal: 2500
                       transactionFileReference: ''
                       invoices:
@@ -730,7 +726,43 @@ paths:
                         creditLineValue: 0
                         debitLineCount: 2
                         debitLineValue: 2500
-                        zeroValueLineCount: 0
+                        zeroLineCount: 0
+                        deminimisInvoice: false
+                        zeroValueInvoice: false
+                        minimumChargeInvoice: false
+                        licences:
+                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                          licenceNumber: FOOO/BARRR/306
+                        - id: 77502697-e274-491a-bd6d-84ec557b0485
+                          licenceNumber: FOOO/BARRR/307
+                        netTotal: 2500
+                05 Approved:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: approved
+                      creditNoteCount: 0
+                      creditNoteValue: 0
+                      invoiceCount: 1
+                      invoiceValue: 2500
+                      creditLineCount: 0
+                      creditLineValue: 0
+                      debitLineCount: 2
+                      debitLineValue: 2500
+                      zeroLineCount: 0
+                      netTotal: 2500
+                      transactionFileReference: ''
+                      invoices:
+                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                        customerReference: TH150000020
+                        financialYear: 2019
+                        creditLineCount: 0
+                        creditLineValue: 0
+                        debitLineCount: 2
+                        debitLineValue: 2500
+                        zeroLineCount: 0
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
@@ -819,12 +851,15 @@ paths:
                 02 Transactions added:
                   value:
                     status: initialised
-                03 Generating summary:
+                03 Generating bill run:
                   value:
                     status: generating
-                04 Summary generated:
+                04 Bill run generated:
                   value:
-                    status: summarised
+                    status: generated
+                05 Approved:
+                  value:
+                    status: aproved
   "/v2/{regime}/bill-runs/{billrunId}/generate":
     patch:
       operationId: GenerateBillRun


### PR DESCRIPTION
Whilst working on the latest changes we spotted one inconsistency with the current examples and what we actually return (it's `zeroLineCount` in the invoice details, not `zeroValueLineCount`).

Also, [Develop Approve Bill Run (v2)](https://trello.com/c/SmiI8YaG) is going to make some changes to the bill run structure which will affect the examples. We'll just use `status:` to show a bill run is 'approved', no need for a separate field and makes things less complex in the code.

So, we cover that change here as well and add a new example to help demonstrate it.