### PR TITLE
Update approve endpoint API V2 documentation

### DIFF
--- a/openapi/version_2/paths/v2/billruns/bill_run_approve.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_approve.yml
@@ -2,7 +2,7 @@ patch:
   operationId: ApproveBillRun
   description: "Approves all transactions in a specified bill run.  Bill run must be unbilled.  Must take place before bill run is sent."
   tags:
-    - unavailable
+    - available
   parameters:
     - $ref: '../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../schema/parameters.yml#/billrunId'

--- a/openapi/version_2/paths/v2/billruns/bill_run_approve.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_approve.yml
@@ -1,6 +1,6 @@
 patch:
   operationId: ApproveBillRun
-  description: "Approves all transactions in a specified bill run.  Bill run must be unbilled.  Must take place before bill run is sent."
+  description: "Approves a specified bill run. Bill run must have a status of 'generated'. Must take place before bill run is sent."
   tags:
     - available
   parameters:
@@ -9,3 +9,12 @@ patch:
   responses:
     '204':
       description: "Success"
+    '409':
+      description: "Failed - the bill run is not in the right state"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 409
+              error: Conflict
+              message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 does not have a status of 'generated'.


### PR DESCRIPTION
The bill run `/approve` endpoint is now complete and will be available in the next Docker release (already in `latest`).