### PR TITLE
Add test bill run generator API details

### DIFF
--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -86,6 +86,9 @@ paths:
   '/admin/health/database':
     $ref: 'paths/admin/health/database.yml'
 
+  '/admin/test/{regime}/bill-runs/':
+    $ref: 'paths/admin/test/bill_runs.yml'
+
   '/v2/{regime}/bill-runs':
     $ref: 'paths/v2/billruns/bill_runs.yml'
 

--- a/openapi/version_2/paths/admin/test/bill_runs.yml
+++ b/openapi/version_2/paths/admin/test/bill_runs.yml
@@ -1,0 +1,79 @@
+post:
+  operationId: CreateTestBillRun
+  description: "This endpoint creates a test bill run for a region. It is intended for quickly creating large bill runs so we can access the performance and operation of endpoints when working with them. You can control the type of invoices generated within the bill run using the request payload. The types are
+
+  - `mixed-invoice` - 2 debit lines and 1 credit line resulting in an invoice
+
+  - `mixed-credit` - 2 credit lines and 1 debit line resulting in a credit note
+
+  - `zero-value` - 3 debit transactions all with a charge value of 0
+
+  - `deminimis` - 3 debit transactions that total less than £5
+
+  - `minimum-charge` - 3 debit transactions that total less than £25 and are all subject to minimum charge
+
+  Every invoice created results in 3 transactions. So, the following request would result in a bill run with 100 invoices and 300 transactions.
+
+  ```
+  {
+    \"region\": \"A\",
+    \"mix\": [
+        { \"type\": \"mixed-invoice\", \"count\": 40 },
+        { \"type\": \"mixed-credit\", \"count\": 40 },
+        { \"type\": \"zero-value\", \"count\": 10 },
+        { \"type\": \"deminimis\", \"count\": 10 }
+    ]
+  }
+  ```
+
+  The endpoint has been designed to generate the bill run as quickly as possible. To do this we **do not** call the rules service. The values used are based on real calculations, but should the rules service calculation change it won't be reflected here.
+
+  The endpoint returns the new bill run ID immediately, but may take sometime to create all the invoices. If you have access to it, check the log for a message that will confirm when the process is complete.
+  "
+  tags:
+    - admin
+  parameters:
+    - $ref: '../../../../schema/parameters.yml#/regime'
+  responses:
+    '201':
+      description: "Success"
+      content:
+        application/json:
+          schema:
+            example:
+              billRun:
+                id: '2bbbe459-966e-4026-b5d2-2f10867bdddd'
+                billRunNumber: 10004
+    '422':
+      description: "Failed - bill run cannot be generated because there is an issue with its data"
+      content:
+        application/json:
+          examples:
+            'Missing region':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: \"region\" is required
+            'Region is unknown':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: \"region\" must be one of [A, B, E, N, S, T, W, Y]
+
+  requestBody:
+    content:
+      application/json:
+        schema:
+          example:
+            region: A
+            mix:
+            - type: mixed-invoice
+              count: 35
+            - type: mixed-credit
+              count: 35
+            - type: zero-value
+              count: 10
+            - type: deminimis
+              count: 10
+            - type: minimum-charge
+              count: 10

--- a/openapi/version_2/paths/admin/test/bill_runs.yml
+++ b/openapi/version_2/paths/admin/test/bill_runs.yml
@@ -12,7 +12,9 @@ post:
 
   - `minimum-charge` - 3 debit transactions that total less than £25 and are all subject to minimum charge
 
+
   Every invoice created results in 3 transactions. So, the following request would result in a bill run with 100 invoices and 300 transactions.
+
 
   ```
   {
@@ -26,7 +28,9 @@ post:
   }
   ```
 
+
   The endpoint has been designed to generate the bill run as quickly as possible. To do this we **do not** call the rules service. The values used are based on real calculations, but should the rules service calculation change it won't be reflected here.
+
 
   The endpoint returns the new bill run ID immediately, but may take sometime to create all the invoices. If you have access to it, check the log for a message that will confirm when the process is complete.
   "

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -775,10 +775,10 @@ paths:
   "/v2/{regime}/bill-runs/{billrunId}/approve":
     patch:
       operationId: ApproveBillRun
-      description: Approves all transactions in a specified bill run.  Bill run must
-        be unbilled.  Must take place before bill run is sent.
+      description: Approves a specified bill run. Bill run must have a status of 'generated'.
+        Must take place before bill run is sent.
       tags:
-      - unavailable
+      - available
       parameters:
       - name: regime
         in: path
@@ -806,6 +806,16 @@ paths:
       responses:
         '204':
           description: Success
+        '409':
+          description: Failed - the bill run is not in the right state
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 409
+                  error: Conflict
+                  message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 does not
+                    have a status of 'generated'.
   "/v2/{regime}/bill-runs/{billrunId}/status":
     get:
       operationId: ViewBillRunStatus

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -520,6 +520,88 @@ paths:
       responses:
         '200':
           description: Success
+  "/admin/test/{regime}/bill-runs/":
+    post:
+      operationId: CreateTestBillRun
+      description: "This endpoint creates a test bill run for a region. It is intended
+        for quickly creating large bill runs so we can access the performance and
+        operation of endpoints when working with them. You can control the type of
+        invoices generated within the bill run using the request payload. The types
+        are\n- `mixed-invoice` - 2 debit lines and 1 credit line resulting in an invoice\n-
+        `mixed-credit` - 2 credit lines and 1 debit line resulting in a credit note\n-
+        `zero-value` - 3 debit transactions all with a charge value of 0\n- `deminimis`
+        - 3 debit transactions that total less than £5\n- `minimum-charge` - 3 debit
+        transactions that total less than £25 and are all subject to minimum charge\n\nEvery
+        invoice created results in 3 transactions. So, the following request would
+        result in a bill run with 100 invoices and 300 transactions.\n\n``` { \"region\":
+        \"A\", \"mix\": [ { \"type\": \"mixed-invoice\", \"count\": 40 }, { \"type\":
+        \"mixed-credit\", \"count\": 40 }, { \"type\": \"zero-value\", \"count\":
+        10 }, { \"type\": \"deminimis\", \"count\": 10 } ] } ```\n\nThe endpoint has
+        been designed to generate the bill run as quickly as possible. To do this
+        we **do not** call the rules service. The values used are based on real calculations,
+        but should the rules service calculation change it won't be reflected here.\n\nThe
+        endpoint returns the new bill run ID immediately, but may take sometime to
+        create all the invoices. If you have access to it, check the log for a message
+        that will confirm when the process is complete. "
+      tags:
+      - admin
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                example:
+                  billRun:
+                    id: 2bbbe459-966e-4026-b5d2-2f10867bdddd
+                    billRunNumber: 10004
+        '422':
+          description: Failed - bill run cannot be generated because there is an issue
+            with its data
+          content:
+            application/json:
+              examples:
+                Missing region:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: \"region\" is required
+                Region is unknown:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: \"region\" must be one of [A, B, E, N, S, T, W, Y]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                region: A
+                mix:
+                - type: mixed-invoice
+                  count: 35
+                - type: mixed-credit
+                  count: 35
+                - type: zero-value
+                  count: 10
+                - type: deminimis
+                  count: 10
+                - type: minimum-charge
+                  count: 10
   "/v2/{regime}/bill-runs":
     post:
       operationId: CreateBillRun


### PR DESCRIPTION
We recently added a new endpoint to the `/admin` path to support being able to generate large bill runs quickly. The intent is to support working with and testing other endpoints to see how they behave with realistic volumes.

Depending on the request sent we can ask the endpoint to create a bill run with a mix of invoice types. This change covers full details about the endpoint, including what the invoice types are, the ratio of invoices to transactions (1 to 3), and how to use it.
