### PR TITLE
Update V2 Open API spec to match v0.4.0 changes

### DIFF
--- a/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
+++ b/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
@@ -2,7 +2,7 @@ get:
   operationId: ViewBillRunInvoice
   description: "Request to view details of an invoice. Returns information about the invoice, each of the licences linked to it, and all transactions linked to each licence."
   tags:
-    - unavailable
+    - available
   parameters:
     - $ref: '../../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../../schema/parameters.yml#/billrunId'
@@ -102,7 +102,7 @@ delete:
   operationId: DeleteBillRunInvoice
   description: "Delete the specified invoice and all linked licences and transactions. As part of the deletion the linked bill run will be updated."
   tags:
-    - unavailable
+    - available
   parameters:
     - $ref: '../../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../../schema/parameters.yml#/billrunId'

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -1124,7 +1124,7 @@ paths:
         the invoice, each of the licences linked to it, and all transactions linked
         to each licence.
       tags:
-      - unavailable
+      - available
       parameters:
       - name: regime
         in: path
@@ -1254,7 +1254,7 @@ paths:
       description: Delete the specified invoice and all linked licences and transactions.
         As part of the deletion the linked bill run will be updated.
       tags:
-      - unavailable
+      - available
       parameters:
       - name: regime
         in: path


### PR DESCRIPTION
We've just created v0.4.0 of [version 2](https://github.com/defra/sroc-charging-module-api) of the API which makes a number of new endpoints available

- Delete an invoice from a bill run
- View a bill run invoice

This updates the V2 open API spec to match the change in status.