### PR TITLE
Update Open API spec for V2 /send endpoint

### DIFF
--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -18,131 +18,1753 @@ info:
     As the status of endpoints change the SROC team will make the updated versions of the API available on [Docker Hub](https://hub.docker.com/r/environmentagency/sroc-charging-module-api).
 
     They will also endeavour to update this spec to match. If unsure about anything, or you see a conflict please contact the team first.
-
-  version: "draft"
+  version: draft
   title: Charging Module API V2
   contact:
     name: SROC Service Team
     email: alan.cruikshanks@environment-agency.gov.uk
-    url: 'https://github.com/DEFRA/sroc-service-team'
+    url: https://github.com/DEFRA/sroc-service-team
   license:
     name: Open Government Licence (OGL)
-    url: 'http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3'
+    url: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3
 servers:
-  - description: Local
-    url: 'http://localhost:3003'
-
+- description: Local
+  url: http://localhost:3003
 tags:
-  - name: ready
-    description: "Tested by SROC team, and reviewed by WRLS. Ready for formal sign-off phase"
-  - name: tested
-    description: "Tested by SROC team but awaiting review and feedback from WRLS team"
-  - name: available
-    description: "Available to start using but has not yet been formally tested by SROC team"
-  - name: unavailable
-    description: "These will become available eventually but are yet to be fully implemented"
-  - name: deprioritised
-    description: "These are intended to be delivered but not as MVP"
-  - name: suggested
-    description: "These could be made available to client systems"
-  - name: status
-    description: "Used to confirm the status of the service. Available to all and ready to use"
-  - name: admin
-    description: "Used to administer, monitor, and test the service. Only available when authenticating as an 'admin'"
-
+- name: ready
+  description: Tested by SROC team, and reviewed by WRLS. Ready for formal sign-off
+    phase
+- name: tested
+  description: Tested by SROC team but awaiting review and feedback from WRLS team
+- name: available
+  description: Available to start using but has not yet been formally tested by SROC
+    team
+- name: unavailable
+  description: These will become available eventually but are yet to be fully implemented
+- name: deprioritised
+  description: These are intended to be delivered but not as MVP
+- name: suggested
+  description: These could be made available to client systems
+- name: status
+  description: Used to confirm the status of the service. Available to all and ready
+    to use
+- name: admin
+  description: Used to administer, monitor, and test the service. Only available when
+    authenticating as an 'admin'
 paths:
-  /:
+  "/":
     get:
       operationId: Root
-      description: "Confirm service is up and running. Exactly the same as `/status`"
+      description: Confirm service is up and running. Exactly the same as `/status`
       tags:
-        - status
+      - status
       responses:
         '200':
-          description: "Success"
+          description: Success
           content:
             application/json:
               schema:
-                $ref: '../schema/schemas.yml#/status'
-
-  /status:
-    $ref: 'paths/status.yml'
-
-  '/admin/regimes':
-    $ref: 'paths/admin/regimes.yml'
-
-  '/admin/regimes/{regimeId}':
-    $ref: 'paths/admin/regime.yml'
-
-  '/admin/authorised-systems':
-    $ref: 'paths/admin/authorised_systems.yml'
-
-  '/admin/authorised-systems/{authorisedSystemId}':
-    $ref: 'paths/admin/authorised_system.yml'
-
-  '/admin/health/airbrake':
-    $ref: 'paths/admin/health/airbrake.yml'
-
-  '/admin/health/database':
-    $ref: 'paths/admin/health/database.yml'
-
-  '/admin/test/{regime}/bill-runs/':
-    $ref: 'paths/admin/test/bill_runs.yml'
-
-  '/admin/test/transaction/{transactionId}':
-    $ref: 'paths/admin/test/transaction.yml'
-
-  '/v2/{regime}/bill-runs':
-    $ref: 'paths/v2/billruns/bill_runs.yml'
-
-  '/v2/{regime}/bill-runs/{billrunId}':
-    $ref: 'paths/v2/billruns/bill_run.yml'
-
-  '/v2/{regime}/bill-runs/{billrunId}/approve':
-    $ref: 'paths/v2/billruns/bill_run_approve.yml'
-
-  '/v2/{regime}/bill-runs/{billrunId}/status':
-    $ref: 'paths/v2/billruns/bill_run_status.yml'
-
-  '/v2/{regime}/bill-runs/{billrunId}/generate':
-    $ref: 'paths/v2/billruns/bill_run_generate.yml'
-
-  '/v2/{regime}/bill-runs/{billrunId}/send':
-    $ref: 'paths/v2/billruns/bill_run_send.yml'
-
-  '/v2/{regime}/bill-runs/{billrunId}/invoices/{invoiceId}':
-    $ref: 'paths/v2/billruns/invoices/invoice.yml'
-
-  '/v2/{regime}/bill-runs/{billrunId}/licences/{licenceId}':
-    $ref: 'paths/v2/billruns/licences/licence.yml'
-
-  '/v2/{regime}/bill-runs/{billrunId}/transactions':
-    $ref: 'paths/v2/billruns/transactions/bill_run_transactions.yml'
-
-  '/v2/{regime}/bill-runs/{billrunId}/transactions/{transactionId}':
-    $ref: 'paths/v2/billruns/transactions/bill_run_transaction.yml'
-
-  '/v2/{regime}/calculate-charge':
-    $ref: 'paths/v2/calculate_charge/calculate_charge.yml'
-
-  '/v2/{regime}/customer-changes':
-    $ref: 'paths/v2/customer_changes/customer_changes.yml'
-
-  '/v2/{regime}/transactions':
-    $ref: 'paths/v2/transactions/transactions.yml'
-
-  '/v2/{regime}/transactions/{transactionId}':
-    $ref: 'paths/v2/transactions/transaction.yml'
-
+                description: Returned by a call to status, it is an object that contains
+                  a copy of the headers found in the original request
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: alive
+  "/status":
+    get:
+      operationId: Status
+      description: Confirm service is up and running
+      tags:
+      - status
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                example:
+                  status: alive
+  "/admin/regimes":
+    get:
+      operationId: ListRegimes
+      description: Request a list of the charging regimes recognised and managed by
+        the service
+      tags:
+      - admin
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  description: Charging regime that will have its own charge rules
+                  type: object
+                  properties:
+                    id:
+                      description: Internal ID (GUID) allocated by the CM when creating
+                        a regime.
+                      type: string
+                      format: uuid
+                      example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                    slug:
+                      type: string
+                      enum:
+                      - cfd
+                      - pas
+                      - wml
+                      - wrls
+                      example: wrls
+                    name:
+                      type: string
+                      example: Water Resources
+                    preSrocCutoffDate:
+                      description: NOT IN MASTER DATA SPECIFICATION
+                      type: string
+                      format: datetime
+                      example: '2020-09-11T11:56:41.578Z'
+                    createdAt:
+                      description: NOT IN MASTER DATA SPECIFICATION
+                      type: string
+                      format: datetime
+                      example: '2020-09-11T11:56:41.578Z'
+                    updatedAt:
+                      description: NOT IN MASTER DATA SPECIFICATION
+                      type: string
+                      format: datetime
+                      example: '2020-09-11T11:56:41.578Z'
+              example:
+              - id: ef5ee223-2ee5-4f02-ace5-35330d9f3781
+                slug: cfd
+                name: Water Quality
+                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+              - id: 6bd74eeb-6beb-41d9-be52-5934a49ecd97
+                slug: pas
+                name: Installations
+                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+              - id: 458834a2-0541-4981-87f6-2c0ec9261661
+                slug: wml
+                name: Waste
+                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+              - id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                slug: wrls
+                name: Water Resources
+                preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+  "/admin/regimes/{regimeId}":
+    get:
+      operationId: ViewRegime
+      description: Request details of a 'regime'.
+      tags:
+      - admin
+      parameters:
+      - name: regimeId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a regime.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a regime.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                description: Charging regime that will have its own charge rules
+                type: object
+                properties:
+                  id:
+                    description: Internal ID (GUID) allocated by the CM when creating
+                      a regime.
+                    type: string
+                    format: uuid
+                    example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                  slug:
+                    type: string
+                    enum:
+                    - cfd
+                    - pas
+                    - wml
+                    - wrls
+                    example: wrls
+                  name:
+                    type: string
+                    example: Water Resources
+                  preSrocCutoffDate:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+                  createdAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+                  updatedAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+              example:
+                id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                slug: wrls
+                name: Water Resources
+                preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+                createdAt: '2020-12-01T09:19:22.065Z'
+                updatedAt: '2020-12-01T09:19:22.065Z'
+                authorisedSystems:
+                - id: b36d674f-b97c-4685-95f3-aacae8c97bde
+                  clientId: 1b1gshltt176v80nsc4fxxxxxx
+                  name: wrls
+                  status: active
+                  admin: 'false'
+                  createdAt: '2020-12-02T09:19:22.065Z'
+                  updatedAt: '2020-12-02T09:19:22.065Z'
+  "/admin/authorised-systems":
+    get:
+      operationId: ListAuthorisedSystems
+      description: Request a list of 'authorised systems'. An authorised system is
+        essentially a user of the API, and this returns those users permitted to access
+        it.
+      tags:
+      - admin
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  authorisedSystems:
+                    type: array
+                    items:
+                      description: Essentially the user account of a system authorised
+                        to use the API. Includes what regimes each account is authorised
+                        to make requests for.
+                      type: object
+                      properties:
+                        id:
+                          description: Internal ID (GUID) allocated by the CM when
+                            creating an authorised system.
+                          type: string
+                          format: uuid
+                          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                        clientId:
+                          description: NOT IN MASTER DATA SPECIFICATION
+                          type: string
+                          example: i7rnixijjrawj7azzhwwxxxxxx
+                        name:
+                          type: string
+                          example: wrls
+                        status:
+                          type: string
+                          example: active
+                        admin:
+                          description: Boolean indicator to show whether or not the
+                            authorised system is an 'admin' user of the API
+                          type: boolean
+                          example: false
+                        createdAt:
+                          description: NOT IN MASTER DATA SPECIFICATION
+                          type: string
+                          format: datetime
+                          example: '2020-09-11T11:56:41.578Z'
+                        updatedAt:
+                          description: NOT IN MASTER DATA SPECIFICATION
+                          type: string
+                          format: datetime
+                          example: '2020-09-11T11:56:41.578Z'
+              example:
+              - id: ac12ac4b-9b9e-4cba-a06f-a90f611a1ef1
+                clientId: 710uhe3hqumsk2da43foxxxxxx
+                name: admin
+                status: active
+                admin: 'true'
+                createdAt: '2020-11-01T09:19:22.065Z'
+                updatedAt: '2020-11-01T09:19:22.065Z'
+              - id: b36d674f-b97c-4685-95f3-aacae8c97bde
+                clientId: 1b1gshltt176v80nsc4fxxxxxx
+                name: wrls
+                status: active
+                admin: 'false'
+                createdAt: '2020-12-02T09:19:22.065Z'
+                updatedAt: '2020-12-02T09:19:22.065Z'
+    post:
+      operationId: AddAuthorisedSystem
+      description: Add a new 'authorised system'. An authorised system is essentially
+        a user of the API, and this adds a new one to it.
+      tags:
+      - admin
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                description: Essentially the user account of a system authorised to
+                  use the API. Includes what regimes each account is authorised to
+                  make requests for.
+                type: object
+                properties:
+                  id:
+                    description: Internal ID (GUID) allocated by the CM when creating
+                      an authorised system.
+                    type: string
+                    format: uuid
+                    example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                  clientId:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    example: i7rnixijjrawj7azzhwwxxxxxx
+                  name:
+                    type: string
+                    example: wrls
+                  status:
+                    type: string
+                    example: active
+                  admin:
+                    description: Boolean indicator to show whether or not the authorised
+                      system is an 'admin' user of the API
+                    type: boolean
+                    example: false
+                  createdAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+                  updatedAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+              example:
+                id: 9e76203a-e900-41a1-a045-2551d98e010c
+                clientId: i7rnixijjrawj7azzhwwxxxxxx
+                name: dashboard
+                status: active
+                admin: 'false'
+                createdAt: '2020-12-04T09:19:22.065Z'
+                updatedAt: '2020-12-04T09:19:22.065Z'
+                regimes:
+                - id: ef5ee223-2ee5-4f02-ace5-35330d9f3781
+                  slug: cfd
+                  name: Water Quality
+                  preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                  createdAt: '2020-12-01T09:19:22.065Z'
+                  updatedAt: '2020-12-01T09:19:22.065Z'
+                - id: 6bd74eeb-6beb-41d9-be52-5934a49ecd97
+                  slug: pas
+                  name: Installations
+                  preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                  createdAt: '2020-12-01T09:19:22.065Z'
+                  updatedAt: '2020-12-01T09:19:22.065Z'
+                - id: 458834a2-0541-4981-87f6-2c0ec9261661
+                  slug: wml
+                  name: Waste
+                  preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
+                  createdAt: '2020-12-01T09:19:22.065Z'
+                  updatedAt: '2020-12-01T09:19:22.065Z'
+                - id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                  slug: wrls
+                  name: Water Resources
+                  preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+                  createdAt: '2020-12-01T09:19:22.065Z'
+                  updatedAt: '2020-12-01T09:19:22.065Z'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: Essentially the user account of a system authorised to
+                use the API. Includes what authorisations each account has.
+              type: object
+              properties:
+                clientId:
+                  description: NOT IN MASTER DATA SPECIFICATION
+                  type: string
+                  example: i7rnixijjrawj7azzhwwxxxxxx
+                name:
+                  type: string
+                  example: wrls
+                status:
+                  type: string
+                  example: active
+                authorisations:
+                  type: array
+                  items:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    enum:
+                    - cfd
+                    - pas
+                    - wml
+                    - wrls
+                    example: wrls
+            example:
+              clientId: i7rnixijjrawj7azzhwwxxxxxx
+              name: dashboard
+              status: active
+              authorisations:
+              - cfd
+              - pas
+              - wml
+              - wrls
+  "/admin/authorised-systems/{authorisedSystemId}":
+    get:
+      operationId: ViewAuthorisedSystem
+      description: Request details of an 'authorised system'. An authorised system
+        is essentially a user of the API, and this returns details about it including
+        which regimes it is authorised to access.
+      tags:
+      - admin
+      parameters:
+      - name: authorisedSystemId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating an authorised
+          system.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating an authorised
+            system.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                description: Essentially the user account of a system authorised to
+                  use the API. Includes what regimes each account is authorised to
+                  make requests for.
+                type: object
+                properties:
+                  id:
+                    description: Internal ID (GUID) allocated by the CM when creating
+                      an authorised system.
+                    type: string
+                    format: uuid
+                    example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                  clientId:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    example: i7rnixijjrawj7azzhwwxxxxxx
+                  name:
+                    type: string
+                    example: wrls
+                  status:
+                    type: string
+                    example: active
+                  admin:
+                    description: Boolean indicator to show whether or not the authorised
+                      system is an 'admin' user of the API
+                    type: boolean
+                    example: false
+                  createdAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+                  updatedAt:
+                    description: NOT IN MASTER DATA SPECIFICATION
+                    type: string
+                    format: datetime
+                    example: '2020-09-11T11:56:41.578Z'
+              example:
+                id: b36d674f-b97c-4685-95f3-aacae8c97bde
+                clientId: 1b1gshltt176v80nsc4fxxxxxx
+                name: wrls
+                status: active
+                admin: 'false'
+                createdAt: '2020-12-02T09:19:22.065Z'
+                updatedAt: '2020-12-02T09:19:22.065Z'
+                regimes:
+                - id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                  slug: wrls
+                  name: Water Resources
+                  preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
+                  createdAt: '2020-12-01T09:19:22.065Z'
+                  updatedAt: '2020-12-01T09:19:22.065Z'
+  "/admin/health/airbrake":
+    get:
+      operationId: CheckAirbrake
+      description: Used to confirm Airbrake is connected correctly to an environment
+      tags:
+      - admin
+      responses:
+        '500':
+          description: An error has been thrown on purpose by the API. Check either
+            the production or non-production instance of Errbit to confirm it received
+            the error
+  "/admin/health/database":
+    get:
+      operationId: CheckDatabase
+      description: |-
+        Used to check the API is correctly connected to the database in an environment. Will also provide some general stats about the data held
+        > The endpoint does return a JSON response. However, it's pretty sizable and just a JSON version of [pg_stat_user_tables](http://www.postgresql.cn/docs/10/monitoring-stats.html#PG-STAT-ALL-TABLES-VIEW). So we don't document it here.
+      tags:
+      - admin
+      responses:
+        '200':
+          description: Success
+  "/admin/test/{regime}/bill-runs/":
+    post:
+      operationId: CreateTestBillRun
+      description: "This endpoint creates a test bill run for a region. It is intended
+        for quickly creating large bill runs so we can access the performance and
+        operation of endpoints when working with them. You can control the type of
+        invoices generated within the bill run using the request payload. The types
+        are\n- `mixed-invoice` - 2 debit lines and 1 credit line resulting in an invoice\n-
+        `mixed-credit` - 2 credit lines and 1 debit line resulting in a credit note\n-
+        `zero-value` - 3 debit transactions all with a charge value of 0\n- `deminimis`
+        - 3 debit transactions that total less than £5\n- `minimum-charge` - 3 debit
+        transactions that total less than £25 and are all subject to minimum charge\n\nEvery
+        invoice created results in 3 transactions. So, the following request would
+        result in a bill run with 100 invoices and 300 transactions.\n\n``` { \"region\":
+        \"A\", \"mix\": [ { \"type\": \"mixed-invoice\", \"count\": 40 }, { \"type\":
+        \"mixed-credit\", \"count\": 40 }, { \"type\": \"zero-value\", \"count\":
+        10 }, { \"type\": \"deminimis\", \"count\": 10 } ] } ```\n\nThe endpoint has
+        been designed to generate the bill run as quickly as possible. To do this
+        we **do not** call the rules service. The values used are based on real calculations,
+        but should the rules service calculation change it won't be reflected here.\n\nThe
+        endpoint returns the new bill run ID immediately, but may take sometime to
+        create all the invoices. If you have access to it, check the log for a message
+        that will confirm when the process is complete. "
+      tags:
+      - admin
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                example:
+                  billRun:
+                    id: 2bbbe459-966e-4026-b5d2-2f10867bdddd
+                    billRunNumber: 10004
+        '422':
+          description: Failed - bill run cannot be generated because there is an issue
+            with its data
+          content:
+            application/json:
+              examples:
+                Missing region:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: \"region\" is required
+                Region is unknown:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: \"region\" must be one of [A, B, E, N, S, T, W, Y]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                region: A
+                mix:
+                - type: mixed-invoice
+                  count: 35
+                - type: mixed-credit
+                  count: 35
+                - type: zero-value
+                  count: 10
+                - type: deminimis
+                  count: 10
+                - type: minimum-charge
+                  count: 10
+  "/admin/test/transaction/{transactionId}":
+    get:
+      operationId: ViewTestTransaction
+      description: |-
+        Request to view _all_ data on a transaction. Includes bill run, invoice and licence details.
+        > _The example provided only contains a subset of all the properties returned. It is intended to give just an indication of the structure._
+      tags:
+      - admin
+      parameters:
+      - name: transactionId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a transaction,
+          not necessarily visible to the user
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a transaction,
+            not necessarily visible to the user
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              example:
+                id: 8b5c01e6-3e73-409a-acb6-8dbd80ea4d3b
+                billRunId: 647196ac-83a8-4f5a-8436-6a2dac00b72d
+                chargeValue: 2093
+                chargeCredit: true
+                billRun:
+                  id: 647196ac-83a8-4f5a-8436-6a2dac00b72d
+                  regimeId: d9346370-fd6d-4a30-abc3-8eb884019fc4
+                  region: A
+                  status: approved
+                licence:
+                  id: 9db3b7b1-62a3-4ab1-8ff4-c62af40792cc
+                  invoiceId: 96d6cde4-8eb9-47d8-bd4a-43f50b2f70e7
+                  billRunId: 647196ac-83a8-4f5a-8436-6a2dac00b72d
+                  licenceNumber: TONY/TF9222/38
+                invoice:
+                  id: 96d6cde4-8eb9-47d8-bd4a-43f50b2f70e7
+                  billRunId: 647196ac-83a8-4f5a-8436-6a2dac00b72d
+                  customerReference: TH230000222
+                  financialYear: 2018
+  "/v2/{regime}/bill-runs":
+    post:
+      operationId: CreateBillRun
+      description: This endpoint triggers creation of a bill run record for a region.
+        Bill run contains no transactions on creation.
+      tags:
+      - tested
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                example:
+                  billRun:
+                    id: 2bbbe459-966e-4026-b5d2-2f10867bdddd
+                    billRunNumber: 10004
+        '422':
+          description: Failed - bill run cannot be generated because there is an issue
+            with its data
+          content:
+            application/json:
+              examples:
+                Missing region:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: \"region\" is required
+                Region is unknown:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: \"region\" must be one of [A, B, E, N, S, T, W, Y]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                region: A
+  "/v2/{regime}/bill-runs/{billrunId}":
+    get:
+      operationId: ViewBillRun
+      description: Request to view a single bill run based on the bill run ID.
+      tags:
+      - available
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              examples:
+                01 Just created:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: initialised
+                      creditNoteCount: 0
+                      creditNoteValue: 0
+                      invoiceCount: 0
+                      invoiceValue: 0
+                      creditLineCount: 0
+                      creditLineValue: 0
+                      debitLineCount: 0
+                      debitLineValue: 0
+                      zeroLineCount: 0
+                      netTotal: 0
+                      transactionFileReference: ''
+                      invoices: []
+                02 Transactions added:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: initialised
+                      creditNoteCount: 0
+                      creditNoteValue: 0
+                      invoiceCount: 0
+                      invoiceValue: 0
+                      creditLineCount: 0
+                      creditLineValue: 0
+                      debitLineCount: 2
+                      debitLineValue: 2500
+                      zeroLineCount: 0
+                      netTotal: 2500
+                      transactionFileReference: ''
+                      invoices:
+                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                        customerReference: TH150000020
+                        financialYear: 2019
+                        creditLineCount: 0
+                        creditLineValue: 0
+                        debitLineCount: 2
+                        debitLineValue: 2500
+                        zeroLineCount: 0
+                        deminimisInvoice: false
+                        zeroValueInvoice: false
+                        minimumChargeInvoice: false
+                        licences:
+                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                          licenceNumber: FOOO/BARRR/306
+                        - id: 77502697-e274-491a-bd6d-84ec557b0485
+                          licenceNumber: FOOO/BARRR/307
+                        netTotal: 2500
+                03 Generating bill run:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: generating
+                      creditNoteCount: 0
+                      creditNoteValue: 0
+                      invoiceCount: 0
+                      invoiceValue: 0
+                      creditLineCount: 0
+                      creditLineValue: 0
+                      debitLineCount: 2
+                      debitLineValue: 2500
+                      zeroLineCount: 0
+                      netTotal: 2500
+                      transactionFileReference: ''
+                      invoices:
+                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                        customerReference: TH150000020
+                        financialYear: 2019
+                        creditLineCount: 0
+                        creditLineValue: 0
+                        debitLineCount: 2
+                        debitLineValue: 2500
+                        zeroLineCount: 0
+                        deminimisInvoice: false
+                        zeroValueInvoice: false
+                        minimumChargeInvoice: false
+                        licences:
+                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                          licenceNumber: FOOO/BARRR/306
+                        - id: 77502697-e274-491a-bd6d-84ec557b0485
+                          licenceNumber: FOOO/BARRR/307
+                        netTotal: 2500
+                04 Bill run generated:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: generated
+                      creditNoteCount: 0
+                      creditNoteValue: 0
+                      invoiceCount: 1
+                      invoiceValue: 2500
+                      creditLineCount: 0
+                      creditLineValue: 0
+                      debitLineCount: 2
+                      debitLineValue: 2500
+                      zeroLineCount: 0
+                      netTotal: 2500
+                      transactionFileReference: ''
+                      invoices:
+                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                        customerReference: TH150000020
+                        financialYear: 2019
+                        creditLineCount: 0
+                        creditLineValue: 0
+                        debitLineCount: 2
+                        debitLineValue: 2500
+                        zeroLineCount: 0
+                        deminimisInvoice: false
+                        zeroValueInvoice: false
+                        minimumChargeInvoice: false
+                        licences:
+                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                          licenceNumber: FOOO/BARRR/306
+                        - id: 77502697-e274-491a-bd6d-84ec557b0485
+                          licenceNumber: FOOO/BARRR/307
+                        netTotal: 2500
+                05 Approved:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: approved
+                      creditNoteCount: 0
+                      creditNoteValue: 0
+                      invoiceCount: 1
+                      invoiceValue: 2500
+                      creditLineCount: 0
+                      creditLineValue: 0
+                      debitLineCount: 2
+                      debitLineValue: 2500
+                      zeroLineCount: 0
+                      netTotal: 2500
+                      transactionFileReference: ''
+                      invoices:
+                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                        customerReference: TH150000020
+                        financialYear: 2019
+                        creditLineCount: 0
+                        creditLineValue: 0
+                        debitLineCount: 2
+                        debitLineValue: 2500
+                        zeroLineCount: 0
+                        deminimisInvoice: false
+                        zeroValueInvoice: false
+                        minimumChargeInvoice: false
+                        licences:
+                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                          licenceNumber: FOOO/BARRR/306
+                        - id: 77502697-e274-491a-bd6d-84ec557b0485
+                          licenceNumber: FOOO/BARRR/307
+                        netTotal: 2500
+    delete:
+      operationId: DeleteBillRun
+      description: Delets a specified bill run and all invoices, licences, and transactions
+        linked to it. Bill run must be unbilled.
+      tags:
+      - unavailable
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '204':
+          description: Success
+  "/v2/{regime}/bill-runs/{billrunId}/approve":
+    patch:
+      operationId: ApproveBillRun
+      description: Approves a specified bill run. Bill run must have a status of 'generated'.
+        Must take place before bill run is sent.
+      tags:
+      - available
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '204':
+          description: Success
+        '409':
+          description: Failed - the bill run is not in the right state
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 409
+                  error: Conflict
+                  message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 does not
+                    have a status of 'generated'.
+  "/v2/{regime}/bill-runs/{billrunId}/status":
+    get:
+      operationId: ViewBillRunStatus
+      description: Request to view the status of a single bill run based on the bill
+        run ID. It is intended to help client systems quickly determine if a bill
+        run is ready to be viewed after a `/generate` request and reduce the load
+        on the API.
+      tags:
+      - available
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              examples:
+                01 Just created:
+                  value:
+                    status: initialised
+                02 Transactions added:
+                  value:
+                    status: initialised
+                03 Generating bill run:
+                  value:
+                    status: generating
+                04 Bill run generated:
+                  value:
+                    status: generated
+                05 Approved:
+                  value:
+                    status: aproved
+  "/v2/{regime}/bill-runs/{billrunId}/generate":
+    patch:
+      operationId: GenerateBillRun
+      description: Generate the summary for the specified bill run. Bill run must
+        be unbilled. Must take place before bill run is sent.
+      tags:
+      - available
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '204':
+          description: Success
+        '409':
+          description: Failed - the bill run is already being generated
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 409
+                  error: Conflict
+                  message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0
+                    is already being generated
+        '422':
+          description: Failed - bill run cannot be generated because there is an issue
+            with its data
+          content:
+            application/json:
+              examples:
+                Bill run unknown:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown
+                Invalid bill run status:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot
+                      be edited because its status is billed
+                No transactions:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0
+                      cannot be generated because it has no transactions
+  "/v2/{regime}/bill-runs/{billrunId}/send":
+    patch:
+      operationId: SendBillRun
+      description: Triggers creation of a transaction file containing all transactions
+        in the bill run. Bill run must be `approved` else the request will be rejected.
+      tags:
+      - available
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '204':
+          description: Success
+        '409':
+          description: Failed - the bill run is not in the right state
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 409
+                  error: Conflict
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not
+                    have a status of 'approved'.
+        '422':
+          description: Failed - bill run cannot be sent because there is an issue
+            with its data
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 422
+                  error: Unprocessable Entity
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be
+                    sent because its status is billed
+  "/v2/{regime}/bill-runs/{billrunId}/invoices/{invoiceId}":
+    get:
+      operationId: ViewBillRunInvoice
+      description: Request to view details of an invoice. Returns information about
+        the invoice, each of the licences linked to it, and all transactions linked
+        to each licence.
+      tags:
+      - available
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      - name: invoiceId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating an invoice.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating an invoice.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              example:
+                invoice:
+                  id: db82bf38-638a-44d3-b1b3-1ae8524d9c38
+                  billRunId: 45ddee2c-c423-4382-8abe-a6a9f284f829
+                  customerReference: TH230000222
+                  financialYear: 2018
+                  creditLineCount: 1
+                  creditLineValue: 2093
+                  debitLineCount: 0
+                  debitLineValue: 0
+                  zeroLineCount: 0
+                  deminimisInvoice: false
+                  zeroValueInvoice: false
+                  minimumChargeInvoice: false
+                  transactionReference:
+                  netTotal: -2093
+                  licences:
+                  - id: f62faabc-d65e-4242-a106-9777c1d57db7
+                    licenceNumber: TONY/TF9222/38
+                    creditLineCount: 1
+                    creditLineValue: 2093
+                    debitLineCount: 0
+                    debitLineValue: 0
+                    zeroLineCount: 0
+                    subjectToMinimumChargeCount: 0
+                    netTotal: -2093
+                    transactions:
+                    - id: 64eebf4e-9400-469b-9fa3-a3f6506b2375
+                      clientId:
+                      chargeValue: 2093
+                      credit: true
+                      status: unbilled
+                      subjectToMinimumCharge: false
+                      minimumChargeAdjustment: false
+                      lineDescription: Well at Chigley Town Hall
+                      periodStart: '2018-04-01T00:00:00.000Z'
+                      periodEnd: '2019-03-31T00:00:00.000Z'
+                      compensationCharge: 'false'
+                      calculation:
+                        __DecisionID__: ba31bd7b-a13e-4820-b15d-6f70fb2c52490
+                        WRLSChargingResponse:
+                          chargeValue: 20.93
+                          decisionPoints:
+                            sourceFactor: 18.66
+                            seasonFactor: 29.856
+                            lossFactor: 0.89568
+                            volumeFactor: 6.22
+                            abatementAdjustment: 24.640156800000003
+                            s127Agreement: 24.640156800000003
+                            s130Agreement: 24.640156800000003
+                            secondPartCharge: false
+                            waterUndertaker: false
+                            eiucFactor: 0
+                            compensationCharge: false
+                            eiucSourceFactor: 0
+                            sucFactor: 24.640156800000003
+                          messages: []
+                          sucFactor: 27.51
+                          volumeFactor: 6.22
+                          sourceFactor: 3
+                          seasonFactor: 1.6
+                          lossFactor: 0.03
+                          abatementAdjustment: S126 x 1.0
+                          s127Agreement:
+                          s130Agreement:
+                          eiucSourceFactor: 0
+                          eiucFactor: 0
+        '404':
+          description: Failed - the invoice is unknown
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
+        '409':
+          description: Failed - the invoice is not linked to that bill run
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 409
+                  error: Conflict
+                  message: Invoice db82bf38-638a-44d3-b1b3-1ae8524d9c38 is not linked
+                    to bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9.
+    delete:
+      operationId: DeleteBillRunInvoice
+      description: Delete the specified invoice and all linked licences and transactions.
+        As part of the deletion the linked bill run will be updated.
+      tags:
+      - available
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      - name: invoiceId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating an invoice.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating an invoice.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '204':
+          description: Success
+  "/v2/{regime}/bill-runs/{billrunId}/licences/{licenceId}":
+    get:
+      operationId: ViewBillRunLicence
+      description: Request to view details of an licence. As we have a licence entity
+        we want to drive all interactions using its ID. We would also prefer to structure
+        the schema as `licence -> transactions` as this matches our structure in the
+        database. However, the actual detail provided below is just to provide a rough
+        example.
+      tags:
+      - suggested
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      - name: licenceId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a licence.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a licence.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              example:
+                licence:
+                  id: fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3
+                  billRunId: fd2ab097-3097-42bd-849e-046aa250a0d0
+                  invoiceId: 559943dd-8d08-4c95-9600-9c6c7d08d0d8
+                  licenceNumber: FOOO/BARRR/306
+                  creditLineCount: 0
+                  creditLineValue: 0
+                  debitLineCount: 2
+                  debitLineValue: 4186
+                  zeroValueLineCount: 1
+                  newLicenceCount: 3
+                  netTotal: 4186
+                  transactions:
+                  - id: fe36eccb-4d58-4cb0-8062-01f7c2b886c2
+                    region: A
+                    credit: false
+                    chargeValue: 2093
+                    minimumChargeAdjustment: false
+                  - id: '08a74e38-3652-44b9-8459-c364d3a3e524'
+                    region: A
+                    credit: false
+                    chargeValue: 2093
+                    minimumChargeAdjustment: false
+                  - id: 9b1cc7c7-4b19-42cc-8d17-90f121edebbb
+                    region: A
+                    credit: false
+                    chargeValue: 0
+                    minimumChargeAdjustment: false
+    delete:
+      operationId: DeleteBillRunLicence
+      description: Delete the specified licence and all linked transactions. As part
+        of the deletion the linked invoice and bill run will also be updated.
+      tags:
+      - unavailable
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      - name: licenceId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a licence.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a licence.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '204':
+          description: Success
+  "/v2/{regime}/bill-runs/{billrunId}/transactions":
+    post:
+      operationId: AddBillRunTransaction
+      description: Triggers creation of a transaction and immediately adds it to the
+        specified bill run.
+      tags:
+      - available
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                example:
+                  transaction:
+                    id: fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3
+                    clientId: 2395429b-e703-43bc-8522-ce3f67507ffa
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                periodStart: 01-APR-2019
+                periodEnd: 31-MAR-2020
+                credit: false
+                billableDays: 310
+                authorisedDays: 365
+                volume: '6.22'
+                source: Supported
+                season: Summer
+                loss: Low
+                twoPartTariff: false
+                compensationCharge: false
+                eiucSource: Tidal
+                waterUndertaker: false
+                regionalChargingArea: Anglian
+                section127Agreement: false
+                section130Agreement: false
+                customerReference: TH230000222
+                lineDescription: Well at Chigley Town Hall
+                licenceNumber: TONY/TF9222/37
+                chargePeriod: 01-APR-2018 - 31-MAR-2019
+                chargeElementId: ''
+                batchNumber: TONY10
+                region: W
+                areaCode: ARCA
+  "/v2/{regime}/bill-runs/{billrunId}/transactions/{transactionId}":
+    get:
+      operationId: ViewBillRunTransaction
+      description: Request to view a single specified transaction included in a specified
+        (billed or unbilled) bill run.
+      tags:
+      - unavailable
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      - name: transactionId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a transaction,
+          not necessarily visible to the user
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a transaction,
+            not necessarily visible to the user
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+  "/v2/{regime}/calculate-charge":
+    post:
+      operationId: CalculateCharge
+      description: Request to calculate a standalone charge based on a set of charge
+        parameters, without creating a transaction. Input and output data is not retained
+        in the CM.
+      tags:
+      - tested
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                example:
+                  calculation:
+                    chargeValue: 772
+                    sourceFactor: 3
+                    seasonFactor: 1.6
+                    lossFactor: 0.03
+                    licenceHolderChargeAgreement:
+                    chargeElementAgreement:
+                    eiucSourceFactor: 0
+                    eiuc: 0
+                    suc: 1495
+      requestBody:
+        content:
+          application/json:
+            schema:
+              example:
+                periodStart: 01-APR-2020
+                periodEnd: 31-MAR-2021
+                credit: false
+                billableDays: 214
+                authorisedDays: 214
+                volume: '3.5865'
+                source: Supported
+                season: Summer
+                loss: Low
+                twoPartTariff: false
+                compensationCharge: false
+                eiucSource: Tidal
+                waterUndertaker: false
+                regionalChargingArea: Midlands
+                section126Factor: 1
+                section127Agreement: false
+                section130Agreement: false
+  "/v2/{regime}/customer-changes":
+    post:
+      operationId: CreateCustomerChange
+      description: Provides details of a single new customer record or a change to
+        an existing customer record for inclusion in a customer file and onward transmission
+        to SSCL
+      tags:
+      - available
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      responses:
+        '204':
+          description: Success
+      requestBody:
+        content:
+          application/json:
+            schema:
+              description: The address details to be updated for a given customer
+                reference and region.
+              type: object
+            example:
+              region: A
+              customerReference: BB02BEEB
+              customerName: Huge Factory Ltd
+              addressLine1: 1 Monster Lane
+              addressLine2: High Town
+              addressLine4: Chigley
+  "/v2/{regime}/transactions":
+    get:
+      operationId: ListTransactions
+      description: Request to view all transactions meeting specified parameters.
+        List may contain both billed and unbilled transactions.
+      tags:
+      - deprioritised
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: page
+        in: query
+        description: In large result sets use to page through them
+        schema:
+          description: When submitting a request that results in a large set of results,
+            this indicates the page number to view. When returned as part of a response
+            it indicates the page number of the data returned.
+          type: integer
+          minimum: 1
+          example: 1
+      - name: perPage
+        in: query
+        description: In large result sets use to control how many to return per page
+        schema:
+          description: When submitting a request that results in a large set of results,
+            this indicates the number of results to be included in each page. When
+            returned as part of a response it indicates the number of results included
+            on each page
+          type: integer
+          minimum: 1
+          maximum: 100
+          example: 50
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+  "/v2/{regime}/transactions/{transactionId}":
+    get:
+      operationId: ViewTransaction
+      description: Request to view a single transaction based on the transaction ID.
+        Transaction may be billed or unbilled.
+      tags:
+      - deprioritised
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: transactionId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a transaction,
+          not necessarily visible to the user
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a transaction,
+            not necessarily visible to the user
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
 security:
-  - OAuth2: []
-
+- OAuth2: []
 components:
   securitySchemes:
     OAuth2:
       type: oauth2
-      description: "The API uses [AWS Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/what-is-amazon-cognito.html) to manage authentication and authorisation. To use it you will first need a cognito client ID and password. You then use these to request a bearer token from AWS Cognito. The bearer token is then sent in the `Authorisation` header of your request"
+      description: The API uses [AWS Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/what-is-amazon-cognito.html)
+        to manage authentication and authorisation. To use it you will first need
+        a cognito client ID and password. You then use these to request a bearer token
+        from AWS Cognito. The bearer token is then sent in the `Authorisation` header
+        of your request
       flows:
         clientCredentials:
-          tokenUrl: 'https://chargingmoduleapi.auth.eu-west-1.amazoncognito.com/oauth2/token'
+          tokenUrl: https://chargingmoduleapi.auth.eu-west-1.amazoncognito.com/oauth2/token
           scopes: {}

--- a/openapi/version_2/paths/v2/billruns/bill_run_send.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_send.yml
@@ -9,6 +9,15 @@ patch:
   responses:
     '204':
       description: "Success"
+    '409':
+      description: "Failed - the bill run is not in the right state"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 409
+              error: Conflict
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not have a status of 'approved'.
     '422':
       description: "Failed - bill run cannot be sent because there is an issue with its data"
       content:

--- a/openapi/version_2/paths/v2/billruns/bill_run_send.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_send.yml
@@ -2,7 +2,7 @@ patch:
   operationId: SendBillRun
   description: "Triggers creation of a transaction file containing all transactions in the bill run. Bill run must be `approved` else the request will be rejected."
   tags:
-    - unavailable
+    - available
   parameters:
     - $ref: '../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../schema/parameters.yml#/billrunId'

--- a/openapi/version_2/paths/v2/billruns/bill_run_send.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_send.yml
@@ -9,14 +9,6 @@ patch:
   responses:
     '204':
       description: "Success"
-      content:
-        application/json:
-          schema:
-            example:
-              billRun:
-                id: fd2ab097-3097-42bd-849e-046aa250a0d0
-                transactionFileReference: nalai50001.dat
-                transactionFileDate: 02-JUN-2020
     '422':
       description: "Failed - bill run cannot be sent because there is an issue with its data"
       content:


### PR DESCRIPTION
The `PATCH /v2/{regimeId}/bill-runs/{billRunId}/send` endpoint is now available. This updates the Open API spec to match what is currently implemented and set the status to 'available'.