### PR TITLE
Update v2 docs with DELETE bill-runs endpoint

### DIFF
--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -178,12 +178,21 @@ get:
 
 delete:
   operationId: DeleteBillRun
-  description: "Delets a specified bill run and all invoices, licences, and transactions linked to it. Bill run must be unbilled."
+  description: "Deletes a specified bill run and all invoices, licences, and transactions linked to it. Bill run must be unbilled."
   tags:
-    - unavailable
+    - available
   parameters:
     - $ref: '../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../schema/parameters.yml#/billrunId'
   responses:
     '204':
       description: "Success"
+    '409':
+      description: "Failed - the bill run is not in the right state"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 409
+              error: Conflict
+              message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 has a status of 'billed'.

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -901,10 +901,10 @@ paths:
                         netTotal: 2500
     delete:
       operationId: DeleteBillRun
-      description: Delets a specified bill run and all invoices, licences, and transactions
+      description: Deletes a specified bill run and all invoices, licences, and transactions
         linked to it. Bill run must be unbilled.
       tags:
-      - unavailable
+      - available
       parameters:
       - name: regime
         in: path
@@ -932,6 +932,16 @@ paths:
       responses:
         '204':
           description: Success
+        '409':
+          description: Failed - the bill run is not in the right state
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 409
+                  error: Conflict
+                  message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 has a status
+                    of 'billed'.
   "/v2/{regime}/bill-runs/{billrunId}/approve":
     patch:
       operationId: ApproveBillRun


### PR DESCRIPTION
https://trello.com/c/IKn83UpO/1927-s-develop-delete-bill-run-v2

This change updates the draft v2 Swagger docs to include the `DELETE /v2/{regime}/bill-runs/{billRunId}` endpoint.