### PR TITLE
Update V2 Open API spec with latest changes

### DIFF
--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -43,20 +43,16 @@ get:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
                       customerReference: 'TH150000020'
                       financialYear: 2019
-                      creditLineCount: 0
-                      creditLineValue: 0
-                      debitLineCount: 2
-                      debitLineValue: 2500
-                      zeroLineCount: 0
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
+                      transactionReference: ''
+                      netTotal: 2500
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
-                      netTotal: 2500
             '03 Generating bill run':
               value:
                 billRun:
@@ -74,20 +70,16 @@ get:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
                       customerReference: 'TH150000020'
                       financialYear: 2019
-                      creditLineCount: 0
-                      creditLineValue: 0
-                      debitLineCount: 2
-                      debitLineValue: 2500
-                      zeroLineCount: 0
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
+                      netTotal: 2500
+                      transactionReference: ''
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
-                      netTotal: 2500
             '04 Bill run generated':
               value:
                 billRun:
@@ -105,20 +97,16 @@ get:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
                       customerReference: 'TH150000020'
                       financialYear: 2019
-                      creditLineCount: 0
-                      creditLineValue: 0
-                      debitLineCount: 2
-                      debitLineValue: 2500
-                      zeroLineCount: 0
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
+                      netTotal: 2500
+                      transactionReference: ''
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
-                      netTotal: 2500
             '05 Approved':
               value:
                 billRun:
@@ -136,20 +124,16 @@ get:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
                       customerReference: 'TH150000020'
                       financialYear: 2019
-                      creditLineCount: 0
-                      creditLineValue: 0
-                      debitLineCount: 2
-                      debitLineValue: 2500
-                      zeroLineCount: 0
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
+                      netTotal: 2500
+                      transactionReference: ''
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
-                      netTotal: 2500
             '06 Sent':
               value:
                 billRun:
@@ -167,20 +151,43 @@ get:
                     - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
                       customerReference: 'TH150000020'
                       financialYear: 2019
-                      creditLineCount: 0
-                      creditLineValue: 0
-                      debitLineCount: 2
-                      debitLineValue: 2500
-                      zeroLineCount: 0
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
+                      netTotal: 2500
+                      transactionReference: 'AAI1000008'
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
+            '07 Billed':
+              value:
+                billRun:
+                  id: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
+                  billRunNumber: 10001
+                  region: 'W'
+                  status: 'billed'
+                  creditNoteCount: 0
+                  creditNoteValue: 0
+                  invoiceCount: 1
+                  invoiceValue: 2500
+                  netTotal: 2500
+                  transactionFileReference: 'nalwi50001'
+                  invoices:
+                    - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
+                      customerReference: 'TH150000020'
+                      financialYear: 2019
+                      deminimisInvoice: false
+                      zeroValueInvoice: false
+                      minimumChargeInvoice: false
                       netTotal: 2500
+                      transactionReference: 'AAI1000008'
+                      licences:
+                        - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
+                          licenceNumber: 'FOOO/BARRR/306'
+                        - id: '77502697-e274-491a-bd6d-84ec557b0485'
+                          licenceNumber: 'FOOO/BARRR/307'
 
 delete:
   operationId: DeleteBillRun

--- a/openapi/version_2/paths/v2/billruns/bill_run_status.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_status.yml
@@ -27,3 +27,12 @@ get:
             '05 Approved':
               value:
                 status: 'aproved'
+            '06 Sent':
+              value:
+                status: 'pending'
+            '07 Billed':
+              value:
+                status: 'billed'
+            '08 Not billed':
+              value:
+                status: 'billing_not_required'

--- a/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
+++ b/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
@@ -18,11 +18,6 @@ get:
               billRunId: 45ddee2c-c423-4382-8abe-a6a9f284f829
               customerReference: TH230000222
               financialYear: 2018
-              creditLineCount: 1
-              creditLineValue: 2093
-              debitLineCount: 0
-              debitLineValue: 0
-              zeroLineCount: 0
               deminimisInvoice: false
               zeroValueInvoice: false
               minimumChargeInvoice: false
@@ -31,12 +26,6 @@ get:
               licences:
               - id: f62faabc-d65e-4242-a106-9777c1d57db7
                 licenceNumber: TONY/TF9222/38
-                creditLineCount: 1
-                creditLineValue: 2093
-                debitLineCount: 0
-                debitLineValue: 0
-                zeroLineCount: 0
-                subjectToMinimumChargeCount: 0
                 netTotal: -2093
                 transactions:
                 - id: 64eebf4e-9400-469b-9fa3-a3f6506b2375

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -767,20 +767,16 @@ paths:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
                         customerReference: TH150000020
                         financialYear: 2019
-                        creditLineCount: 0
-                        creditLineValue: 0
-                        debitLineCount: 2
-                        debitLineValue: 2500
-                        zeroLineCount: 0
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
+                        transactionReference: ''
+                        netTotal: 2500
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
                         - id: 77502697-e274-491a-bd6d-84ec557b0485
                           licenceNumber: FOOO/BARRR/307
-                        netTotal: 2500
                 03 Generating bill run:
                   value:
                     billRun:
@@ -798,20 +794,16 @@ paths:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
                         customerReference: TH150000020
                         financialYear: 2019
-                        creditLineCount: 0
-                        creditLineValue: 0
-                        debitLineCount: 2
-                        debitLineValue: 2500
-                        zeroLineCount: 0
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
+                        netTotal: 2500
+                        transactionReference: ''
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
                         - id: 77502697-e274-491a-bd6d-84ec557b0485
                           licenceNumber: FOOO/BARRR/307
-                        netTotal: 2500
                 04 Bill run generated:
                   value:
                     billRun:
@@ -829,20 +821,16 @@ paths:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
                         customerReference: TH150000020
                         financialYear: 2019
-                        creditLineCount: 0
-                        creditLineValue: 0
-                        debitLineCount: 2
-                        debitLineValue: 2500
-                        zeroLineCount: 0
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
+                        netTotal: 2500
+                        transactionReference: ''
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
                         - id: 77502697-e274-491a-bd6d-84ec557b0485
                           licenceNumber: FOOO/BARRR/307
-                        netTotal: 2500
                 05 Approved:
                   value:
                     billRun:
@@ -860,20 +848,16 @@ paths:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
                         customerReference: TH150000020
                         financialYear: 2019
-                        creditLineCount: 0
-                        creditLineValue: 0
-                        debitLineCount: 2
-                        debitLineValue: 2500
-                        zeroLineCount: 0
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
+                        netTotal: 2500
+                        transactionReference: ''
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
                         - id: 77502697-e274-491a-bd6d-84ec557b0485
                           licenceNumber: FOOO/BARRR/307
-                        netTotal: 2500
                 06 Sent:
                   value:
                     billRun:
@@ -891,20 +875,43 @@ paths:
                       - id: aa630ae0-0e51-4166-9025-66576c513f7f
                         customerReference: TH150000020
                         financialYear: 2019
-                        creditLineCount: 0
-                        creditLineValue: 0
-                        debitLineCount: 2
-                        debitLineValue: 2500
-                        zeroLineCount: 0
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
+                        netTotal: 2500
+                        transactionReference: AAI1000008
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
                         - id: 77502697-e274-491a-bd6d-84ec557b0485
                           licenceNumber: FOOO/BARRR/307
+                07 Billed:
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: billed
+                      creditNoteCount: 0
+                      creditNoteValue: 0
+                      invoiceCount: 1
+                      invoiceValue: 2500
+                      netTotal: 2500
+                      transactionFileReference: nalwi50001
+                      invoices:
+                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                        customerReference: TH150000020
+                        financialYear: 2019
+                        deminimisInvoice: false
+                        zeroValueInvoice: false
+                        minimumChargeInvoice: false
                         netTotal: 2500
+                        transactionReference: AAI1000008
+                        licences:
+                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                          licenceNumber: FOOO/BARRR/306
+                        - id: 77502697-e274-491a-bd6d-84ec557b0485
+                          licenceNumber: FOOO/BARRR/307
     delete:
       operationId: DeleteBillRun
       description: Deletes a specified bill run and all invoices, licences, and transactions
@@ -1046,6 +1053,15 @@ paths:
                 05 Approved:
                   value:
                     status: aproved
+                06 Sent:
+                  value:
+                    status: pending
+                07 Billed:
+                  value:
+                    status: billed
+                '08 Not billed':
+                  value:
+                    status: billing_not_required
   "/v2/{regime}/bill-runs/{billrunId}/generate":
     patch:
       operationId: GenerateBillRun
@@ -1220,11 +1236,6 @@ paths:
                   billRunId: 45ddee2c-c423-4382-8abe-a6a9f284f829
                   customerReference: TH230000222
                   financialYear: 2018
-                  creditLineCount: 1
-                  creditLineValue: 2093
-                  debitLineCount: 0
-                  debitLineValue: 0
-                  zeroLineCount: 0
                   deminimisInvoice: false
                   zeroValueInvoice: false
                   minimumChargeInvoice: false
@@ -1233,12 +1244,6 @@ paths:
                   licences:
                   - id: f62faabc-d65e-4242-a106-9777c1d57db7
                     licenceNumber: TONY/TF9222/38
-                    creditLineCount: 1
-                    creditLineValue: 2093
-                    debitLineCount: 0
-                    debitLineValue: 0
-                    zeroLineCount: 0
-                    subjectToMinimumChargeCount: 0
                     netTotal: -2093
                     transactions:
                     - id: 64eebf4e-9400-469b-9fa3-a3f6506b2375


### PR DESCRIPTION
This update is just some housekeeping and updates to the V2 open API spec based on fixes and changes we have made recently.

- update view bill run examples to remove line count/value fields
- update view bill run examples to include invoice transaction reference
- add view bill run examples for `sent` and `billed`
- update view invoice response to remove line count/value fields
- add all remaining status examples to status endpoint
