### PR TITLE
Update CMA V2 Open API spec with latest changes

### DIFF
--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -47,6 +47,8 @@ get:
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
                       transactionReference: ''
+                      creditLineValue: 0
+                      debitLineValue: 2500
                       netTotal: 2500
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
@@ -73,8 +75,10 @@ get:
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
-                      netTotal: 2500
                       transactionReference: ''
+                      creditLineValue: 0
+                      debitLineValue: 2500
+                      netTotal: 2500
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -100,8 +104,10 @@ get:
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
-                      netTotal: 2500
                       transactionReference: ''
+                      creditLineValue: 0
+                      debitLineValue: 2500
+                      netTotal: 2500
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -127,8 +133,10 @@ get:
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
-                      netTotal: 2500
                       transactionReference: ''
+                      creditLineValue: 0
+                      debitLineValue: 2500
+                      netTotal: 2500
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -154,8 +162,10 @@ get:
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
-                      netTotal: 2500
                       transactionReference: 'AAI1000008'
+                      creditLineValue: 0
+                      debitLineValue: 2500
+                      netTotal: 2500
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -181,8 +191,10 @@ get:
                       deminimisInvoice: false
                       zeroValueInvoice: false
                       minimumChargeInvoice: false
-                      netTotal: 2500
                       transactionReference: 'AAI1000008'
+                      creditLineValue: 0
+                      debitLineValue: 2500
+                      netTotal: 2500
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'

--- a/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
+++ b/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
@@ -22,6 +22,8 @@ get:
               zeroValueInvoice: false
               minimumChargeInvoice: false
               transactionReference:
+              creditLineValue: 2093
+              debitLineValue: 0
               netTotal: -2093
               licences:
               - id: f62faabc-d65e-4242-a106-9777c1d57db7

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -771,6 +771,8 @@ paths:
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
                         transactionReference: ''
+                        creditLineValue: 0
+                        debitLineValue: 2500
                         netTotal: 2500
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
@@ -797,8 +799,10 @@ paths:
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
-                        netTotal: 2500
                         transactionReference: ''
+                        creditLineValue: 0
+                        debitLineValue: 2500
+                        netTotal: 2500
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -824,8 +828,10 @@ paths:
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
-                        netTotal: 2500
                         transactionReference: ''
+                        creditLineValue: 0
+                        debitLineValue: 2500
+                        netTotal: 2500
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -851,8 +857,10 @@ paths:
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
-                        netTotal: 2500
                         transactionReference: ''
+                        creditLineValue: 0
+                        debitLineValue: 2500
+                        netTotal: 2500
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -878,8 +886,10 @@ paths:
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
-                        netTotal: 2500
                         transactionReference: AAI1000008
+                        creditLineValue: 0
+                        debitLineValue: 2500
+                        netTotal: 2500
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -905,8 +915,10 @@ paths:
                         deminimisInvoice: false
                         zeroValueInvoice: false
                         minimumChargeInvoice: false
-                        netTotal: 2500
                         transactionReference: AAI1000008
+                        creditLineValue: 0
+                        debitLineValue: 2500
+                        netTotal: 2500
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -1240,6 +1252,8 @@ paths:
                   zeroValueInvoice: false
                   minimumChargeInvoice: false
                   transactionReference:
+                  creditLineValue: 2093
+                  debitLineValue: 0
                   netTotal: -2093
                   licences:
                   - id: f62faabc-d65e-4242-a106-9777c1d57db7


### PR DESCRIPTION
With the release of SROC CMA V2 v0.6.2 this change is some minor updates to the examples to bring them in line with what the API is now doing.