### PR TITLE
Update V2 Open API spec to latest

### DIFF
--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -200,6 +200,35 @@ get:
                           licenceNumber: 'FOOO/BARRR/306'
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
+            '08 Billing not required':
+              value:
+                billRun:
+                  id: 'fd2ab097-3097-42bd-849e-046aa250a0d0'
+                  billRunNumber: 10001
+                  region: 'W'
+                  status: 'billing_not_required'
+                  creditNoteCount: 0
+                  creditNoteValue: 0
+                  invoiceCount: 0
+                  invoiceValue: 0
+                  netTotal: 0
+                  transactionFileReference: ''
+                  invoices:
+                    - id: 'aa630ae0-0e51-4166-9025-66576c513f7f'
+                      customerReference: 'TH150000020'
+                      financialYear: 2019
+                      deminimisInvoice: false
+                      zeroValueInvoice: false
+                      minimumChargeInvoice: false
+                      transactionReference: ''
+                      creditLineValue: 2500
+                      debitLineValue: 2500
+                      netTotal: 0
+                      licences:
+                        - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
+                          licenceNumber: 'FOOO/BARRR/306'
+                        - id: '77502697-e274-491a-bd6d-84ec557b0485'
+                          licenceNumber: 'FOOO/BARRR/307'
 
 delete:
   operationId: DeleteBillRun

--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -2,7 +2,7 @@ get:
   operationId: ViewBillRun
   description: "Request to view a single bill run based on the bill run ID."
   tags:
-    - available
+    - tested
   parameters:
     - $ref: '../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../schema/parameters.yml#/billrunId'
@@ -234,7 +234,7 @@ delete:
   operationId: DeleteBillRun
   description: "Deletes a specified bill run and all invoices, licences, and transactions linked to it. Bill run must be unbilled."
   tags:
-    - available
+    - tested
   parameters:
     - $ref: '../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../schema/parameters.yml#/billrunId'

--- a/openapi/version_2/paths/v2/billruns/bill_run_approve.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_approve.yml
@@ -2,7 +2,7 @@ patch:
   operationId: ApproveBillRun
   description: "Approves a specified bill run. Bill run must have a status of 'generated'. Must take place before bill run is sent."
   tags:
-    - available
+    - tested
   parameters:
     - $ref: '../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../schema/parameters.yml#/billrunId'

--- a/openapi/version_2/paths/v2/billruns/bill_run_generate.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_generate.yml
@@ -2,7 +2,7 @@ patch:
   operationId: GenerateBillRun
   description: "Generate the summary for the specified bill run. Bill run must be unbilled. Must take place before bill run is sent."
   tags:
-    - available
+    - tested
   parameters:
     - $ref: '../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../schema/parameters.yml#/billrunId'

--- a/openapi/version_2/paths/v2/billruns/bill_run_status.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run_status.yml
@@ -2,7 +2,7 @@ get:
   operationId: ViewBillRunStatus
   description: "Request to view the status of a single bill run based on the bill run ID. It is intended to help client systems quickly determine if a bill run is ready to be viewed after a `/generate` request and reduce the load on the API."
   tags:
-    - available
+    - tested
   parameters:
     - $ref: '../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../schema/parameters.yml#/billrunId'

--- a/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
+++ b/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
@@ -2,7 +2,7 @@ get:
   operationId: ViewBillRunInvoice
   description: "Request to view details of an invoice. Returns information about the invoice, each of the licences linked to it, and all transactions linked to each licence."
   tags:
-    - available
+    - tested
   parameters:
     - $ref: '../../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../../schema/parameters.yml#/billrunId'
@@ -93,7 +93,7 @@ delete:
   operationId: DeleteBillRunInvoice
   description: "Delete the specified invoice and all linked licences and transactions. As part of the deletion the linked bill run will be updated."
   tags:
-    - available
+    - tested
   parameters:
     - $ref: '../../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../../schema/parameters.yml#/billrunId'

--- a/openapi/version_2/paths/v2/billruns/transactions/bill_run_transactions.yml
+++ b/openapi/version_2/paths/v2/billruns/transactions/bill_run_transactions.yml
@@ -2,7 +2,7 @@ post:
   operationId: AddBillRunTransaction
   description: "Triggers creation of a transaction and immediately adds it to the specified bill run."
   tags:
-    - available
+    - tested
   parameters:
     - $ref: '../../../../../schema/parameters.yml#/regime'
     - $ref: '../../../../../schema/parameters.yml#/billrunId'

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -705,7 +705,7 @@ paths:
       operationId: ViewBillRun
       description: Request to view a single bill run based on the bill run ID.
       tags:
-      - available
+      - tested
       parameters:
       - name: regime
         in: path
@@ -924,12 +924,41 @@ paths:
                           licenceNumber: FOOO/BARRR/306
                         - id: 77502697-e274-491a-bd6d-84ec557b0485
                           licenceNumber: FOOO/BARRR/307
+                '08 Billing not required':
+                  value:
+                    billRun:
+                      id: fd2ab097-3097-42bd-849e-046aa250a0d0
+                      billRunNumber: 10001
+                      region: W
+                      status: billing_not_required
+                      creditNoteCount: 0
+                      creditNoteValue: 0
+                      invoiceCount: 0
+                      invoiceValue: 0
+                      netTotal: 0
+                      transactionFileReference: ''
+                      invoices:
+                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                        customerReference: TH150000020
+                        financialYear: 2019
+                        deminimisInvoice: false
+                        zeroValueInvoice: false
+                        minimumChargeInvoice: false
+                        transactionReference: ''
+                        creditLineValue: 2500
+                        debitLineValue: 2500
+                        netTotal: 0
+                        licences:
+                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                          licenceNumber: FOOO/BARRR/306
+                        - id: 77502697-e274-491a-bd6d-84ec557b0485
+                          licenceNumber: FOOO/BARRR/307
     delete:
       operationId: DeleteBillRun
       description: Deletes a specified bill run and all invoices, licences, and transactions
         linked to it. Bill run must be unbilled.
       tags:
-      - available
+      - tested
       parameters:
       - name: regime
         in: path
@@ -973,7 +1002,7 @@ paths:
       description: Approves a specified bill run. Bill run must have a status of 'generated'.
         Must take place before bill run is sent.
       tags:
-      - available
+      - tested
       parameters:
       - name: regime
         in: path
@@ -1019,7 +1048,7 @@ paths:
         run is ready to be viewed after a `/generate` request and reduce the load
         on the API.
       tags:
-      - available
+      - tested
       parameters:
       - name: regime
         in: path
@@ -1080,7 +1109,7 @@ paths:
       description: Generate the summary for the specified bill run. Bill run must
         be unbilled. Must take place before bill run is sent.
       tags:
-      - available
+      - tested
       parameters:
       - name: regime
         in: path
@@ -1203,7 +1232,7 @@ paths:
         the invoice, each of the licences linked to it, and all transactions linked
         to each licence.
       tags:
-      - available
+      - tested
       parameters:
       - name: regime
         in: path
@@ -1324,7 +1353,7 @@ paths:
       description: Delete the specified invoice and all linked licences and transactions.
         As part of the deletion the linked bill run will be updated.
       tags:
-      - available
+      - tested
       parameters:
       - name: regime
         in: path
@@ -1486,7 +1515,7 @@ paths:
       description: Triggers creation of a transaction and immediately adds it to the
         specified bill run.
       tags:
-      - available
+      - tested
       parameters:
       - name: regime
         in: path


### PR DESCRIPTION
There are no real changes to any of the API end points. We have added some more examples to cover when a bill run has been determined as `billing_not_required`.

The key changes are moving some of the endpoints to the status of `tested` to reflect the work @anwarisse1 has been doing.