### PR TITLE
Add subjectToMinimumCharge to Swagger docs

### DIFF
--- a/openapi/version_2/paths/v2/billruns/transactions/bill_run_transactions.yml
+++ b/openapi/version_2/paths/v2/billruns/transactions/bill_run_transactions.yml
@@ -23,6 +23,7 @@ post:
           example:
             periodStart: '01-APR-2019'
             periodEnd: '31-MAR-2020'
+            subjectToMinimumCharge: false
             credit: false
             billableDays: 310
             authorisedDays: 365

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -1528,6 +1528,7 @@ paths:
               example:
                 periodStart: 01-APR-2019
                 periodEnd: 31-MAR-2020
+                subjectToMinimumCharge: false
                 credit: false
                 billableDays: 310
                 authorisedDays: 365


### PR DESCRIPTION
A recent defect report from WRLS team highlighted that they maybe didn't realise that v2 has shifted from using `newLicence` to `subjectToMinimumCharge`. This change amends the example request for `AddBillRunTransaction` to include this.