### PR TITLE
Remove transaction status from OpenAPI V2 spec

### DIFF
--- a/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
+++ b/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
@@ -34,7 +34,6 @@ get:
                   clientId:
                   chargeValue: 2093
                   credit: true
-                  status: unbilled
                   subjectToMinimumCharge: false
                   minimumChargeAdjustment: false
                   lineDescription: Well at Chigley Town Hall

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -1293,7 +1293,6 @@ paths:
                       clientId:
                       chargeValue: 2093
                       credit: true
-                      status: unbilled
                       subjectToMinimumCharge: false
                       minimumChargeAdjustment: false
                       lineDescription: Well at Chigley Town Hall


### PR DESCRIPTION
As per [Remove transaction level status](https://github.com/DEFRA/sroc-charging-module-api/pull/340) the status property has been removed from bill run transactions.

This change updates the V2 Open API spec to match.