### PR TITLE
Add invoice rebill endpoint to V2 OpenAPI spec

### DIFF
--- a/openapi/schema/parameters.yml
+++ b/openapi/schema/parameters.yml
@@ -93,6 +93,20 @@ perPage:
   description: "In large result sets use to control how many to return per page"
   schema:
     $ref: 'fields.yml#/perPage'
+rebillBillrunId:
+  name: rebillBillrunId
+  in: path
+  required: true
+  description: "Internal ID (GUID) allocated by the CM when creating a bill run. When rebilling this represents the bill run you want to assign the new rebill invoices to."
+  schema:
+    $ref: 'fields.yml#/billrunId'
+rebillInvoiceId:
+  name: rebillInvoiceId
+  in: path
+  required: true
+  description: "Internal ID (GUID) allocated by the CM when creating an invoice. When rebilling this represents the invoice you wish to rebill."
+  schema:
+    $ref: 'fields.yml#/invoiceId'
 regime:
   name: regime
   in: path

--- a/openapi/version_2/openapi.yml
+++ b/openapi/version_2/openapi.yml
@@ -122,6 +122,9 @@ paths:
   '/v2/{regime}/bill-runs/{billrunId}/invoices/{invoiceId}':
     $ref: 'paths/v2/billruns/invoices/invoice.yml'
 
+  '/v2/{regime}/bill-runs/{rebillBillrunId}/invoices/{rebillInvoiceId}/rebill':
+    $ref: 'paths/v2/billruns/invoices/invoice_rebill.yml'
+
   '/v2/{regime}/bill-runs/{billrunId}/licences/{licenceId}':
     $ref: 'paths/v2/billruns/licences/licence.yml'
 

--- a/openapi/version_2/paths/v2/billruns/invoices/invoice_rebill.yml
+++ b/openapi/version_2/paths/v2/billruns/invoices/invoice_rebill.yml
@@ -1,0 +1,45 @@
+get:
+  operationId: RebillBillRunInvoice
+  description: "Request to rebill an invoice. Returns ID of the invoice that will cancel out the original invoice, and the one to replace it."
+  tags:
+    - suggested
+  parameters:
+    - $ref: '../../../../../schema/parameters.yml#/regime'
+    - $ref: '../../../../../schema/parameters.yml#/rebillBillrunId'
+    - $ref: '../../../../../schema/parameters.yml#/rebillInvoiceId'
+  responses:
+    '201':
+      description: "Success"
+      content:
+        application/json:
+          example:
+            invoices:
+            - id: f62faabc-d65e-4242-a106-9777c1d57db7
+              rebilledType: C
+            - id: db82bf38-638a-44d3-b1b3-1ae8524d9c38
+              rebilledType: R
+    '409':
+      description: "Failed - the invoice has already been rebilled"
+      content:
+        application/json:
+          examples:
+            'Invoice already rebilled':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 has already been rebilled.
+            'Invoice already on bill run':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is already on bill run aa630ae0-0e51-4166-9025-66576c513f7f.
+            'Invoice on an unbilled bill run':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Bill run aa630ae0-0e51-4166-9025-66576c513f7f does not have a status of 'billed'.
+            'Invoice is for a different region':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is for region T but bill run aa630ae0-0e51-4166-9025-66576c513f7f is for region A.

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -1497,6 +1497,90 @@ paths:
       responses:
         '204':
           description: Success
+  "/v2/{regime}/bill-runs/{rebillBillrunId}/invoices/{rebillInvoiceId}/rebill":
+    get:
+      operationId: RebillBillRunInvoice
+      description: Request to rebill an invoice. Returns ID of the invoice that will
+        cancel out the original invoice, and the one to replace it.
+      tags:
+      - suggested
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: NOT IN MASTER DATA SPECIFICATION
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: rebillBillrunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          When rebilling this represents the bill run you want to assign the new rebill
+          invoices to.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      - name: rebillInvoiceId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating an invoice.
+          When rebilling this represents the invoice you wish to rebill.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating an invoice.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              example:
+                invoices:
+                - id: f62faabc-d65e-4242-a106-9777c1d57db7
+                  rebilledType: C
+                - id: db82bf38-638a-44d3-b1b3-1ae8524d9c38
+                  rebilledType: R
+        '409':
+          description: Failed - the invoice has already been rebilled
+          content:
+            application/json:
+              examples:
+                Invoice already rebilled:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 has already
+                      been rebilled.
+                Invoice already on bill run:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is already
+                      on bill run aa630ae0-0e51-4166-9025-66576c513f7f.
+                Invoice on an unbilled bill run:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Bill run aa630ae0-0e51-4166-9025-66576c513f7f does not
+                      have a status of 'billed'.
+                Invoice is for a different region:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is for
+                      region T but bill run aa630ae0-0e51-4166-9025-66576c513f7f is
+                      for region A.
   "/v2/{regime}/bill-runs/{billrunId}/licences/{licenceId}":
     get:
       operationId: ViewBillRunLicence


### PR DESCRIPTION
Add details for the new bill run invoice rebilling endpoint to the V2 OpenAPI spec. At this time there is currently an endpoint available, but it's not doing all the checks outlined here or returning the response we've documented. This is why it is recorded as being 'suggested'. We'll bump it to available just as soon as we have hooked the endpoint up to the new services.