### PR TITLE
Add rebilling fields to View Bill Run and Bill Run Invoice docs

### DIFF
--- a/openapi/version_2/paths/v2/billruns/bill_run.yml
+++ b/openapi/version_2/paths/v2/billruns/bill_run.yml
@@ -50,6 +50,8 @@ get:
                       creditLineValue: 0
                       debitLineValue: 2500
                       netTotal: 2500
+                      rebilledType: 'O'
+                      rebilledInvoiceId: null
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -79,6 +81,8 @@ get:
                       creditLineValue: 0
                       debitLineValue: 2500
                       netTotal: 2500
+                      rebilledType: 'O'
+                      rebilledInvoiceId: null
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -108,6 +112,8 @@ get:
                       creditLineValue: 0
                       debitLineValue: 2500
                       netTotal: 2500
+                      rebilledType: 'O'
+                      rebilledInvoiceId: null
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -137,6 +143,8 @@ get:
                       creditLineValue: 0
                       debitLineValue: 2500
                       netTotal: 2500
+                      rebilledType: 'O'
+                      rebilledInvoiceId: null
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -166,6 +174,8 @@ get:
                       creditLineValue: 0
                       debitLineValue: 2500
                       netTotal: 2500
+                      rebilledType: 'O'
+                      rebilledInvoiceId: null
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'
@@ -195,6 +205,8 @@ get:
                       creditLineValue: 0
                       debitLineValue: 2500
                       netTotal: 2500
+                      rebilledType: 'O'
+                      rebilledInvoiceId: null
                       licences:
                         - id: '3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea'
                           licenceNumber: 'FOOO/BARRR/306'

--- a/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
+++ b/openapi/version_2/paths/v2/billruns/invoices/invoice.yml
@@ -25,6 +25,8 @@ get:
               creditLineValue: 2093
               debitLineValue: 0
               netTotal: -2093
+              rebilledType: 'O'
+              rebilledInvoiceId: null
               licences:
               - id: f62faabc-d65e-4242-a106-9777c1d57db7
                 licenceNumber: TONY/TF9222/38

--- a/openapi/versions/draft_v2.yml
+++ b/openapi/versions/draft_v2.yml
@@ -774,6 +774,8 @@ paths:
                         creditLineValue: 0
                         debitLineValue: 2500
                         netTotal: 2500
+                        rebilledType: O
+                        rebilledInvoiceId:
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -803,6 +805,8 @@ paths:
                         creditLineValue: 0
                         debitLineValue: 2500
                         netTotal: 2500
+                        rebilledType: O
+                        rebilledInvoiceId:
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -832,6 +836,8 @@ paths:
                         creditLineValue: 0
                         debitLineValue: 2500
                         netTotal: 2500
+                        rebilledType: O
+                        rebilledInvoiceId:
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -861,6 +867,8 @@ paths:
                         creditLineValue: 0
                         debitLineValue: 2500
                         netTotal: 2500
+                        rebilledType: O
+                        rebilledInvoiceId:
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -890,6 +898,8 @@ paths:
                         creditLineValue: 0
                         debitLineValue: 2500
                         netTotal: 2500
+                        rebilledType: O
+                        rebilledInvoiceId:
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -919,6 +929,8 @@ paths:
                         creditLineValue: 0
                         debitLineValue: 2500
                         netTotal: 2500
+                        rebilledType: O
+                        rebilledInvoiceId:
                         licences:
                         - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
                           licenceNumber: FOOO/BARRR/306
@@ -1255,6 +1267,8 @@ paths:
                   creditLineValue: 2093
                   debitLineValue: 0
                   netTotal: -2093
+                  rebilledType: O
+                  rebilledInvoiceId:
                   licences:
                   - id: f62faabc-d65e-4242-a106-9777c1d57db7
                     licenceNumber: TONY/TF9222/38


### PR DESCRIPTION
[Recent](https://github.com/DEFRA/sroc-charging-module-api/pull/421) [changes](https://github.com/DEFRA/sroc-charging-module-api/pull/422) have added rebilling fields to the output of the View Bill Run and View Bill Run Invoice endpoints. This change updates the docs to reflect these changes.