### PR TITLE
Update OpenAPI README's

### DIFF
--- a/openapi/README.md
+++ b/openapi/README.md
@@ -1,34 +1,12 @@
 # OpenAPI documentation
 
-This folder contains everything we use to maintain an [OpenAPI specification](https://github.com/OAI/OpenAPI-Specification) for both [Version 1](https://github.com/DEFRA/charging-module-api) and [Version 2](https://github.com/DEFRA/sroc-charging-module-api) of our API's.
+This folder contains everything we use to maintain an [OpenAPI specification](https://github.com/OAI/OpenAPI-Specification) for [SROC Charging Module API](https://github.com/DEFRA/sroc-charging-module-api).
 
-These specs serve both as a reference for us and our users. They can also be used with tools like [Postman](https://www.postman.com/) and [SwaggerHub](https://swagger.io/tools/swaggerhub/).
+The spec serves both as a reference for us and our users. It can also be used with tools like [Postman](https://www.postman.com/) and [SwaggerHub](https://swagger.io/tools/swaggerhub/).
 
-As changes are made to the APIs the development team is expected to update the specs to match. See [Maintaing the Draft versions](#maintaing-the-draft-versions) for more details.
+As changes are made to the API the development team is expected to update the spec to match. See [Maintaining the Draft version](#maintaing-the-draft-version) for more details.
 
-We use [SwaggerHub](https://swagger.io/tools/swaggerhub/) to publish the specs in a form that all interested parties can interact with to learn about the API.
-
-## Versions of the API
-
-For reasons covered below the team is currently maintaining and working on 2 versions of the API.
-
-### Version 1
-
-This represents the current 'released' (available to users but not yet 'live') version of the API and is based on the [charging-module-api project](https://github.com/DEFRA/charging-module-api). User testing has exposed serious issues with performance so this version has been superceded. But because we have external users using and developing against it still we treat it as a 'live' system. This is why we continue to maintain and make available the Open API spec for it.
-
-The `draft` version is available at <https://app.swaggerhub.com/apis-docs/sro/charging-module_api/draft>.
-
-Other versions available are
-
-- [v0.4.0](https://app.swaggerhub.com/apis-docs/sro/charging-module_api/v0.4.0)
-- [v0.3.0](https://app.swaggerhub.com/apis-docs/sro/charging-module_api/v0.3.0)
-- [v0.2.0](https://app.swaggerhub.com/apis-docs/sro/charging-module_api/v0.2.0)
-
-### Version 2
-
-This represents the latest version of the API and is based on the [sroc-charging-module-api project](https://github.com/DEFRA/sroc-charging-module-api). It is intended to resolve the quality and performance issues in version 1. It has also been designed to provide more flexibility and less duplication as new regimes are added.
-
-It is not yet available to users and the team is still working on what endpoints will be available on release, and how they will behave. At this time only the `draft` version is available at <https://app.swaggerhub.com/apis-docs/sro/sroc-charging-module-api/draft>.
+We use [SwaggerHub](https://swagger.io/tools/swaggerhub/) to publish the spec in a form that all interested parties can interact with to learn about the API.
 
 ## Working on the documents
 
@@ -38,9 +16,9 @@ Any editor or tool that supports OpenAPI should be able to work with the documen
 
 ### Cache issues with the extension
 
-The **open-api designer** does suffer with a [caching issue](https://github.com/philosowaffle/vs-openapi-designer/issues/36) when it comes to working with multiple Open API files. First, it expects the file to be previewed or compiled to be called `openapi.yml`. Second, if you open the [version 1 file](/openapi/version_1/openapi.yml) first and preview it, you'll find if you then open the [version 2 file](/openapi/version_2/openapi.yml) the preview won't update. No amount of closing the pane seems and trying again solves it.
+The **open-api designer** does suffer with a [caching issue](https://github.com/philosowaffle/vs-openapi-designer/issues/36) when it comes to working with the main `openapi.yml`. First, it expects the file to be previewed or compiled to be called `openapi.yml`. Anything else and it won't work.
 
-We have found make a couple of edits, saving after each one, it will cause the preview to start showing the file being worked on. If all else fails, close VSCode completely and stick to just working on 1 file at a time 🥺😩 !
+Second, if you open the file and preview it, then do something like move it and makes changes, you'll find when you open the preview again it won't update. No amount of closing the pane and trying again solves this. If this happens just restart VSCode 🥺😩 !
 
 ### Understanding OpenAPI v3
 
@@ -48,25 +26,19 @@ As the OpenAPI spec is just version 3 of the [Swagger spec](https://swagger.io/d
 
 You can also access the [full spec](https://github.com/OAI/OpenAPI-Specification) on GitHub.
 
-## Maintaing the Draft versions
+## Maintaing the Draft version
 
-We maintain 'draft' specs of each version of the API, which we publish to SwaggerHub alongside our release versions.
+We maintain a 'draft' spec of the API, which we publish to SwaggerHub alongside our release versions at <https://app.swaggerhub.com/apis-docs/sro/sroc-charging-module-api/draft>.
 
-Anyone making a change to the specs is expected to also regenerate the relevant draft version.
-
-- [version 1 draft spec](/openapi/version_1/openapi.yml)
-- [version 1 generated draft](/openapi/versions/draft_v1.yml)
-
-- [version 2 draft spec](/openapi/version_2/openapi.yml)
-- [version 2 generated draft](/openapi/versions/draft_v2.yml)
+Anyone making a change to the spec is expected to also regenerate the [draft version](/openapi/versions/draft_v2.yml).
 
 ### Generate draft.yml
 
-In order to upload our specs to SwaggerHub we need to create a unified version of the schema i.e. a single file.
+In order to upload our spec to SwaggerHub we need to create a unified version of the schema i.e. a single file.
 
-The **open-api designer** includes a feature that will compile a unified schema and dereferences all `$refs` into a single JSON file (`openapi/openapi.json`).
+The **open-api designer** includes a feature that will compile a unified schema that dereferences all `$refs` into a single JSON file (`openapi/openapi.json`).
 
-As `yml` is still the prefered option by most tools, including **SwaggerHub**, we use an online tool like [JSON2YAML](https://www.json2yaml.com/) to convert the JSON to yml. Copy the contents of `openapi/openapi.json` to **JSON2YAML**. Once converted replace the contents of the relevant generated draft version with the generated YAML.
+As `yml` is still the prefered option by most tools, including **SwaggerHub**, we use an online tool like [JSON2YAML](https://www.json2yaml.com/) to convert the JSON to yml. Copy the contents of `openapi/openapi.json` to **JSON2YAML**. Once converted replace the contents of the draft version with the generated YAML.
 
 ### Updating SwaggerHub
 
@@ -74,9 +46,7 @@ Because we have no money, we are having to take advantage of the free version of
 
 ## Publishing a release version
 
-> Currently only **Version 1** is 'released'. **Version 2** is still undergoing design and development
-
-For each release of the Charging Module API V1 we
+For each release of the API we
 
 - ensure the spec is up to date
 - tag and save a unified version of the spec to [versions](openapi/versions)
@@ -86,13 +56,13 @@ There's a few steps we have to go through to do this.
 
 ### Update the spec
 
-Ensure the OpenAPI spec is up to date with any changes made to the **Charging Module API V1**. This might be documenting changes in how endpoints behave, the schema because an endpoint has amended how it responds etc.
+Ensure the OpenAPI spec is up to date with any changes made to the API. This might be documenting changes in how endpoints behave, the schema because an endpoint has amended how it responds etc.
 
 If final changes are required follow [Maintaing the Draft version](#maintaing-the-draft-version).
 
 ### Tag and save version of the spec
 
-With [draft_v1.yml](/openapi/versions/draft_v1.yml) updated duplicate the file then rename the copy to match the release version of the API, for example `v0-3-0.yml`.
+With [draft.yml](/openapi/versions/draft_v1.yml) updated duplicate the file then rename the copy to match the release version of the API, for example `v0-3-0.yml`.
 
 You then need to make 2 small tweaks to the new file (both are at the top so you won't get lost!)
 
@@ -121,6 +91,16 @@ When we find errors we will endeavour to update the specs and re-publish them.
 
 GDS and the Open standards board [recommends that government organisations use OpenAPI v3](https://www.gov.uk/government/publications/recommended-open-standards-for-government/describing-restful-apis-with-openapi-3) to document their API's.
 
-They do also expect a lot of other information in the documentation. What we have here we think gives our team and our users a good introduction to the Charging Module API.
+They do also expect a lot of other information in the documentation. What we have here we think gives our team and our users a good introduction to the SROC Charging Module API.
 
 But it is our aim is to build on this to improve what we provide.
+
+## Note about versions
+
+If you go digging through the commit history you will find references to **Version 1** and **Version 2** of the API. Version 1 was the original project the current delivery team were handed when joining the team. You can see the initial version specs we created for it here
+
+- [v0.4.0](https://app.swaggerhub.com/apis-docs/sro/charging-module_api/v0.4.0)
+- [v0.3.0](https://app.swaggerhub.com/apis-docs/sro/charging-module_api/v0.3.0)
+- [v0.2.0](https://app.swaggerhub.com/apis-docs/sro/charging-module_api/v0.2.0)
+
+User testing however exposed serious issues with its performance. Plus, it was overloaded with features and endpoints that our current users confirmed would never be used. So, we quickly moved to replacing it with the current [SROC Charging Module API](https://github.com/DEFRA/sroc-charging-module-api), often referred to as **Version 2**.


### PR DESCRIPTION
Implementing [Update V2 OpenAPI spec ready for API release](https://github.com/DEFRA/sroc-service-team/pull/69) was a major restructuring of the project regards our OpenAPI specs. In essence, we now only maintain one.

However, we still have README's that refer to the maintenance of both specs. This change rectifies them to make things clear we now only maintain the one.