### PR TITLE
Add admin send bill run endpoint to docs

### DIFF
--- a/openapi/README.md
+++ b/openapi/README.md
@@ -30,7 +30,7 @@ You can also access the [full spec](https://github.com/OAI/OpenAPI-Specification
 
 We maintain a 'draft' spec of the API, which we publish to SwaggerHub alongside our release versions at <https://app.swaggerhub.com/apis-docs/sro/sroc-charging-module-api/draft>.
 
-Anyone making a change to the spec is expected to also regenerate the [draft version](/openapi/versions/draft_v2.yml).
+Anyone making a change to the spec is expected to also regenerate the [draft version](/openapi/versions/draft.yml).
 
 ### Generate draft.yml
 

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -70,6 +70,9 @@ paths:
   '/admin/authorised-systems/{authorisedSystemId}':
     $ref: 'paths/admin/authorised_system.yml'
 
+  '/admin/{regime}/bill-runs/{billRunId}/send':
+    $ref: 'paths/admin/bill_runs.yml'
+
   '/admin/{regime}/customers':
     $ref: 'paths/admin/customers.yml'
 

--- a/openapi/paths/admin/bill_runs.yml
+++ b/openapi/paths/admin/bill_runs.yml
@@ -1,6 +1,6 @@
 patch:
   operationId: AdminSendBillRun
-  description: "Triggers creation of a transaction file containing all transactions in the bill run. Bill run must be `pending` else the request will be rejected. Due to the syncronous nature of file creation, the endpoint will immediately return a `204` response; any errors will be shown in the logs."
+  description: "Triggers creation of a transaction file containing all transactions in the bill run. Bill run must be `pending` else the request will be rejected. This endpoint will wait until the file has been created before returning a response."
   tags:
     - admin
   parameters:
@@ -9,3 +9,12 @@ patch:
   responses:
     '204':
       description: "Success"
+    '409':
+      description: "Failed - the bill run is not in the right state"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 409
+              error: Conflict
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not have a status of 'pending'.

--- a/openapi/paths/admin/bill_runs.yml
+++ b/openapi/paths/admin/bill_runs.yml
@@ -1,0 +1,11 @@
+patch:
+  operationId: AdminSendBillRun
+  description: "Triggers creation of a transaction file containing all transactions in the bill run. Bill run must be `pending` else the request will be rejected. Due to the syncronous nature of file creation, the endpoint will immediately return a `204` response; any errors will be shown in the logs."
+  tags:
+    - admin
+  parameters:
+    - $ref: '../../schema/parameters.yml#/regime'
+    - $ref: '../../schema/parameters.yml#/billRunId'
+  responses:
+    '204':
+      description: "Success"

--- a/openapi/versions/draft.yml
+++ b/openapi/versions/draft.yml
@@ -1,3 +1,4 @@
+---
 openapi: 3.0.0
 info:
   description: |
@@ -764,8 +765,8 @@ paths:
       operationId: AdminSendBillRun
       description: Triggers creation of a transaction file containing all transactions
         in the bill run. Bill run must be `pending` else the request will be rejected.
-        Due to the syncronous nature of file creation, the endpoint will immediately
-        return a `204` response; any errors will be shown in the logs.
+        This endpoint will wait until the file has been created before returning a
+        response.
       tags:
       - admin
       parameters:
@@ -797,6 +798,16 @@ paths:
       responses:
         '204':
           description: Success
+        '409':
+          description: Failed - the bill run is not in the right state
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 409
+                  error: Conflict
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not
+                    have a status of 'pending'.
   "/admin/{regime}/customers":
     patch:
       operationId: SendCustomer

--- a/openapi/versions/draft.yml
+++ b/openapi/versions/draft.yml
@@ -11,7 +11,7 @@ info:
 
     ## Running the API locally
 
-    The **SROC service team** also provide a [Docker image](https://hub.docker.com/r/environmentagency/sroc-charging-module-api) you can use to run the API locally. Checkout out their [docs](https://github.com/DEFRA/sroc-service-team/tree/main/dockerhub/version_2) for info on how to get it up and running locally.
+    The **SROC service team** also provide a [Docker image](https://hub.docker.com/r/environmentagency/sroc-charging-module-api) you can use to run the API locally. Checkout out their [docs](https://github.com/DEFRA/sroc-service-team/tree/main/dockerhub) for info on how to get it up and running locally.
   version: draft
   title: SROC Charging Module API
   contact:
@@ -683,6 +683,44 @@ paths:
               - pas
               - wml
               - wrls
+  "/admin/{regime}/bill-runs/{billRunId}/send":
+    patch:
+      operationId: AdminSendBillRun
+      description: Triggers creation of a transaction file containing all transactions
+        in the bill run. Bill run must be `pending` else the request will be rejected.
+        Due to the syncronous nature of file creation, the endpoint will immediately
+        return a `204` response; any errors will be shown in the logs.
+      tags:
+      - admin
+      parameters:
+      - name: regime
+        in: path
+        required: true
+        description: Charging regime to use
+        schema:
+          description: Short reference for a regime, referred to as a 'slug'. This
+            is also what we expect to see in the path as the regime identifier when
+            making a request
+          type: string
+          enum:
+          - cfd
+          - pas
+          - wml
+          - wrls
+          example: wrls
+      - name: billRunId
+        in: path
+        required: true
+        description: Internal ID (GUID) allocated by the CM when creating a bill run.
+        schema:
+          description: Internal ID (GUID) allocated by the CM when creating a bill
+            run.
+          type: string
+          format: uuid
+          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '204':
+          description: Success
   "/admin/{regime}/customers":
     patch:
       operationId: SendCustomer


### PR DESCRIPTION
After [creating the admin 'send bill run' endpoint](https://github.com/DEFRA/sroc-charging-module-api/pull/429), we add it to the Swagger docs.