### PR TITLE
Add details about the customer file to API spec

### DIFF
--- a/openapi/paths/v2/customer_changes/customer_changes.yml
+++ b/openapi/paths/v2/customer_changes/customer_changes.yml
@@ -1,8 +1,6 @@
 post:
   operationId: CreateCustomerChange
-  description: Provides details of a single new customer record or a change to
-    an existing customer record for inclusion in a customer file and onward transmission
-    to SSCL
+  description: Provides details of a single new customer record or a change to an existing customer record for inclusion in a customer file and onward transmission to SSCL
   tags:
   - customer
   parameters:

--- a/openapi/paths/v2/customer_changes/customer_changes.yml
+++ b/openapi/paths/v2/customer_changes/customer_changes.yml
@@ -1,6 +1,72 @@
 post:
   operationId: CreateCustomerChange
-  description: Provides details of a single new customer record or a change to an existing customer record for inclusion in a customer file and onward transmission to SSCL
+  description: |
+    Provides details of a single new customer record or a change to an existing customer record for inclusion in a customer file and onward transmission to SSCL
+
+    ## Customer import file
+
+    The purpose of sending this customer information to the CM is so that it can be transferred to SSCL SOP to update its records. Then when it generates the invoices for customers it has the correct details.
+
+    ### Triggering the file
+
+    Each **bill run** is linked to a **regime** and region. When a **bill run** is 'sent' the CM will also check if any customer changes for the same **regime** and region are outstanding.
+
+    Should no **bill runs** be 'sent' that week, the CM has a weekly scheduled task to pick up the remaining changes and generate files for them.
+
+    ### Customer file reference
+
+    In both cases the CM will generate a **customer file** record and reference number (one for each **regime** and region). The outstanding changes will be linked to this new record which will be marked as `pending`.
+
+    The CM will then generate the customer import file and transfer it to an AWS S3 bucket. From there it will be picked up by an [FME job](https://www.safe.com/fme/) which will grab the file and handle the transfer to a location accessible by SSCL SOP.
+
+    Once transferred to the AWS S3 bucket the changes will be deleted and the **customer file** record's status updated to `exported`. The only detail the CM retains from the change is the customer reference so we can audit when and in what file a change was submitted.
+
+    ### Customer file details
+
+    The customer import file is made up of 3 sections.
+
+    #### Head
+
+    The first row in the file
+
+    | Column Index | Example | Notes |
+    |--------------|---------|-------|
+    | 1  | `H` | Row type indicator |
+    | 2  | `0000001` | Row index |
+    | 3  | `NAL` | Regime reference |
+    | 4  | `A` | Region |
+    | 5  | `C` | File type indicator |
+    | 6  | `nalac50001` | Customer file reference |
+    | 7  | `25 March 2021` | Date the file was generated |
+
+    #### Body
+
+    Each change is represented by a row in the body section
+
+    | Column Index | Example | Notes |
+    |--------------|---------|-------|
+    | 1  | `D` | Row type indicator |
+    | 2  | `0000002` | Row index |
+    | 3  | `TH230000222` | Customer reference |
+    | 4  | `Environment Agency` | Customer name |
+    | 5  | `Permits dept.` | Address line 1 |
+    | 6  | `4th Floor` | Address line 1 |
+    | 7  | `Horizon House` | Address line 2 |
+    | 8  | `Deanery Road` | Address line 3 |
+    | 9  | `Bristol` | Address line 4 |
+    | 10 | `United Kingdom` | Address line 5 |
+    | 11 | `BS1 5AH` | Postcode |
+
+    #### Tail
+
+    The last row in the file is used to confirm how many lines there are
+
+    | Column Index | Example | Notes |
+    |--------------|---------|-------|
+    | 1  | `T` | Row type indicator |
+    | 2  | `0000003` | Row index |
+    | 3  | `3` | Row count |
+
   tags:
   - customer
   parameters:


### PR DESCRIPTION
We currently make reference to a customer file that the CM generates and sends to SSCL SOP. However, we don't actually provide any details about it.

This change adds a bit more info plus an example of the file to the OpenAPI spec.