### PR TITLE
Add details about the transaction file to API spec

### DIFF
--- a/openapi/paths/v2/bill_runs/bill_run_send.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_send.yml
@@ -1,6 +1,105 @@
 patch:
   operationId: SendBillRun
-  description: "Triggers creation of a transaction file containing all transactions in the bill run. Bill run must be `approved` else the request will be rejected."
+  description: |
+    Triggers creation of a transaction file containing all transactions in the bill run. Bill run must be `approved` else the request will be rejected.
+
+    ## Transaction import file
+
+    Once a **bill run** has been 'generated' and 'approved' it can be 'sent' to SSCL SOP. When the 'send' endpoint is hit the CM will generate the transaction file for the specified **bill run**.
+
+    The file contains the information SOP needs to generate invoices and credit notes for customers.
+
+    ### Transaction file reference
+
+    Each **bill run** is linked to a **regime** and region. Each combination has its own sequence counter. When a **bill run** is 'sent' the CM will generate a transaction file reference based on the **regime**, region and next sequence counter. This will be assigned to the **bill run** and its status will be updated to `pending`.
+
+    The CM will then generate the transaction import file and transfer it to an AWS S3 bucket. From there it will be picked up by an [FME job](https://www.safe.com/fme/) which will grab the file and handle the transfer to a location accessible by SSCL SOP.
+
+    Once transferred to the AWS S3 bucket the **bill run's* status will be updated to `billed`.
+
+    > _If a bill run contains no chargeable invoices or credit notes, for example, because they are zero value, the status will be updated to `billing_not_required`_
+
+    ### Transaction file details
+
+    The transaction import file is made up of 3 sections.
+
+    #### Head
+
+    The first row in the file
+
+    | Column Index | Example | Notes |
+    |--------------|---------|-------|
+    | 1  | `H` | Row type indicator |
+    | 2  | `0000000` | Row index |
+    | 3  | `NAL` | Regime reference |
+    | 4  | `A` | Region |
+    | 5  | `I` | File type indicator |
+    | 6  | `50001` | Transaction file reference |
+    | 7  | `10001` | Bill run number |
+    | 8  | `25 March 2021` | Date the file was generated |
+
+    #### Body
+
+    Each transaction is represented by a row in the body section
+
+    | Column Index | Example | Notes |
+    |--------------|---------|-------|
+    | 1  | `D` | Row type indicator |
+    | 2  | `0000001` | Row index |
+    | 3  | `TH230000222` | Customer reference |
+    | 4  | `25 March 2021` | Date the file was generated |
+    | 5  | `I` | Invoice (I) or Credit Note (C) |
+    | 6  | `AAI1000001` | Transaction reference |
+    | 7  |  | Unused |
+    | 8  | `GBP` | Currency (always GBP) |
+    | 9  |  | Unused |
+    | 10 | `25 March 2021` | Date the file was generated |
+    | 11  |  | Unused |
+    | 12 |  | Unused |
+    | 13 |  | Unused |
+    | 14 |  | Unused |
+    | 15 |  | Unused |
+    | 16 |  | Unused |
+    | 17 |  | Unused |
+    | 18 |  | Unused |
+    | 19 |  | Unused |
+    | 20 | `31517` | Transaction value (signed) |
+    | 21 |  | Unused |
+    | 22 | `ARCA` | Line area code |
+    | 23 | `Well at Chigley Town Hall` | Line description |
+    | 24 | `A` | (always A) |
+    | 25 |  | Unused |
+    | 26 | `A43814_TST` | Licence number (blank if compensation charge or minimum charge is true) |
+    | 27 | `01-APR-2020 - 31-MAR-2021` | Charge period (blank if compensation charge or minimum charge is true) |
+    | 28 | `310/365` | Prorata days (blank if compensation charge or minimum charge is true) |
+    | 29 | `1384` | Volume (blank if compensation charge or minimum charge is true) |
+    | 30 | `5586 Ml` | Volume in mega litres (blank if compensation charge or minimum charge is true) |
+    | 31 | `0.2` | Source factor (blank if compensation charge or minimum charge is true) |
+    | 32 | `1.6` | Season factor (blank if compensation charge or minimum charge is true) |
+    | 33 | `0.03` | Loss factor (blank if compensation charge or minimum charge is true) |
+    | 34 | `S130U x 0.5` | Licence holder charge agreement (blank if compensation charge or minimum charge is true) |
+    | 35 | `S127 x 0.5` | Charge element agreement (blank if compensation charge or minimum charge is true) |
+    | 36 |  | Unused |
+    | 37 |  | Unused |
+    | 38 | `0.2` | Environmental Improvement Unit Charge (EIUC) Source factor |
+    | 39 | `0.2` | EIUC |
+    | 40 |  | Unused |
+    | 41 | `1` | (always 1) |
+    | 42 | `Each` | (always Each) |
+    | 43 | `31517` | Transaction value (signed) |
+
+    #### Tail
+
+    The last row in the file is used to confirm how many lines there are and summarise the totals
+
+    | Column Index | Example | Notes |
+    |--------------|---------|-------|
+    | 1  | `T` | Row type indicator |
+    | 2  | `0000002` | Row index |
+    | 3  | `3` | Row count |
+    | 4  | `31517` | Invoice value |
+    | 5  | `0` | Credit note value (signed) |
+
   tags:
     - bill-run
   parameters:

--- a/openapi/versions/draft.yml
+++ b/openapi/versions/draft.yml
@@ -2322,8 +2322,105 @@ paths:
   "/v2/{regime}/bill-runs/{billRunId}/send":
     patch:
       operationId: SendBillRun
-      description: Triggers creation of a transaction file containing all transactions
-        in the bill run. Bill run must be `approved` else the request will be rejected.
+      description: |
+        Triggers creation of a transaction file containing all transactions in the bill run. Bill run must be `approved` else the request will be rejected.
+
+        ## Transaction import file
+
+        Once a **bill run** has been 'generated' and 'approved' it can be 'sent' to SSCL SOP. When the 'send' endpoint is hit the CM will generate the transaction file for the specified **bill run**.
+
+        The file contains the information SOP needs to generate invoices and credit notes for customers.
+
+        ### Transaction file reference
+
+        Each **bill run** is linked to a **regime** and region. Each combination has its own sequence counter. When a **bill run** is 'sent' the CM will generate a transaction file reference based on the **regime**, region and next sequence counter. This will be assigned to the **bill run** and its status will be updated to `pending`.
+
+        The CM will then generate the transaction import file and transfer it to an AWS S3 bucket. From there it will be picked up by an [FME job](https://www.safe.com/fme/) which will grab the file and handle the transfer to a location accessible by SSCL SOP.
+
+        Once transferred to the AWS S3 bucket the **bill run's* status will be updated to `billed`.
+
+        > _If a bill run contains no chargeable invoices or credit notes, for example, because they are zero value, the status will be updated to `billing_not_required`_
+
+        ### Transaction file details
+
+        The transaction import file is made up of 3 sections.
+
+        #### Head
+
+        The first row in the file
+
+        | Column Index | Example | Notes |
+        |--------------|---------|-------|
+        | 1  | `H` | Row type indicator |
+        | 2  | `0000000` | Row index |
+        | 3  | `NAL` | Regime reference |
+        | 4  | `A` | Region |
+        | 5  | `I` | File type indicator |
+        | 6  | `50001` | Transaction file reference |
+        | 7  | `10001` | Bill run number |
+        | 8  | `25 March 2021` | Date the file was generated |
+
+        #### Body
+
+        Each transaction is represented by a row in the body section
+
+        | Column Index | Example | Notes |
+        |--------------|---------|-------|
+        | 1  | `D` | Row type indicator |
+        | 2  | `0000001` | Row index |
+        | 3  | `TH230000222` | Customer reference |
+        | 4  | `25 March 2021` | Date the file was generated |
+        | 5  | `I` | Invoice (I) or Credit Note (C) |
+        | 6  | `AAI1000001` | Transaction reference |
+        | 7  |  | Unused |
+        | 8  | `GBP` | Currency (always GBP) |
+        | 9  |  | Unused |
+        | 10 | `25 March 2021` | Date the file was generated |
+        | 11  |  | Unused |
+        | 12 |  | Unused |
+        | 13 |  | Unused |
+        | 14 |  | Unused |
+        | 15 |  | Unused |
+        | 16 |  | Unused |
+        | 17 |  | Unused |
+        | 18 |  | Unused |
+        | 19 |  | Unused |
+        | 20 | `31517` | Transaction value (signed) |
+        | 21 |  | Unused |
+        | 22 | `ARCA` | Line area code |
+        | 23 | `Well at Chigley Town Hall` | Line description |
+        | 24 | `A` | (always A) |
+        | 25 |  | Unused |
+        | 26 | `A43814_TST` | Licence number (blank if compensation charge or minimum charge is true) |
+        | 27 | `01-APR-2020 - 31-MAR-2021` | Charge period (blank if compensation charge or minimum charge is true) |
+        | 28 | `310/365` | Prorata days (blank if compensation charge or minimum charge is true) |
+        | 29 | `1384` | Volume (blank if compensation charge or minimum charge is true) |
+        | 30 | `5586 Ml` | Volume in mega litres (blank if compensation charge or minimum charge is true) |
+        | 31 | `0.2` | Source factor (blank if compensation charge or minimum charge is true) |
+        | 32 | `1.6` | Season factor (blank if compensation charge or minimum charge is true) |
+        | 33 | `0.03` | Loss factor (blank if compensation charge or minimum charge is true) |
+        | 34 | `S130U x 0.5` | Licence holder charge agreement (blank if compensation charge or minimum charge is true) |
+        | 35 | `S127 x 0.5` | Charge element agreement (blank if compensation charge or minimum charge is true) |
+        | 36 |  | Unused |
+        | 37 |  | Unused |
+        | 38 | `0.2` | Environmental Improvement Unit Charge (EIUC) Source factor |
+        | 39 | `0.2` | EIUC |
+        | 40 |  | Unused |
+        | 41 | `1` | (always 1) |
+        | 42 | `Each` | (always Each) |
+        | 43 | `31517` | Transaction value (signed) |
+
+        #### Tail
+
+        The last row in the file is used to confirm how many lines there are and summarise the totals
+
+        | Column Index | Example | Notes |
+        |--------------|---------|-------|
+        | 1  | `T` | Row type indicator |
+        | 2  | `0000002` | Row index |
+        | 3  | `3` | Row count |
+        | 4  | `31517` | Invoice value |
+        | 5  | `0` | Credit note value (signed) |
       tags:
       - bill-run
       parameters:


### PR DESCRIPTION
We currently make reference to a transaction file that the CM generates and sends to SSCL SOP. However, we don't actually provide any details about it.

This change adds a bit more info plus an example of the file to the OpenAPI spec.