### PR TITLE
Fix Open API spec customer file details

### DIFF
--- a/openapi/paths/v2/customer_changes/customer_changes.yml
+++ b/openapi/paths/v2/customer_changes/customer_changes.yml
@@ -32,11 +32,11 @@ post:
     | Column Index | Example | Notes |
     |--------------|---------|-------|
     | 1  | `H` | Row type indicator |
-    | 2  | `0000001` | Row index |
+    | 2  | `0000000` | Row index |
     | 3  | `NAL` | Regime reference |
     | 4  | `A` | Region |
     | 5  | `C` | File type indicator |
-    | 6  | `nalac50001` | Customer file reference |
+    | 6  | `50001` | Customer file reference |
     | 7  | `25 March 2021` | Date the file was generated |
 
     #### Body
@@ -46,7 +46,7 @@ post:
     | Column Index | Example | Notes |
     |--------------|---------|-------|
     | 1  | `D` | Row type indicator |
-    | 2  | `0000002` | Row index |
+    | 2  | `0000001` | Row index |
     | 3  | `TH230000222` | Customer reference |
     | 4  | `Environment Agency` | Customer name |
     | 5  | `Permits dept.` | Address line 1 |
@@ -64,7 +64,7 @@ post:
     | Column Index | Example | Notes |
     |--------------|---------|-------|
     | 1  | `T` | Row type indicator |
-    | 2  | `0000003` | Row index |
+    | 2  | `0000002` | Row index |
     | 3  | `3` | Row count |
 
   tags:

--- a/openapi/versions/draft.yml
+++ b/openapi/versions/draft.yml
@@ -2968,11 +2968,11 @@ paths:
         | Column Index | Example | Notes |
         |--------------|---------|-------|
         | 1  | `H` | Row type indicator |
-        | 2  | `0000001` | Row index |
+        | 2  | `0000000` | Row index |
         | 3  | `NAL` | Regime reference |
         | 4  | `A` | Region |
         | 5  | `C` | File type indicator |
-        | 6  | `nalac50001` | Customer file reference |
+        | 6  | `50001` | Customer file reference |
         | 7  | `25 March 2021` | Date the file was generated |
 
         #### Body
@@ -2982,7 +2982,7 @@ paths:
         | Column Index | Example | Notes |
         |--------------|---------|-------|
         | 1  | `D` | Row type indicator |
-        | 2  | `0000002` | Row index |
+        | 2  | `0000001` | Row index |
         | 3  | `TH230000222` | Customer reference |
         | 4  | `Environment Agency` | Customer name |
         | 5  | `Permits dept.` | Address line 1 |
@@ -3000,7 +3000,7 @@ paths:
         | Column Index | Example | Notes |
         |--------------|---------|-------|
         | 1  | `T` | Row type indicator |
-        | 2  | `0000003` | Row index |
+        | 2  | `0000002` | Row index |
         | 3  | `3` | Row count |
       tags:
       - customer


### PR DESCRIPTION
In [Add details about the customer file to API spec](https://github.com/DEFRA/sroc-service-team/pull/77) we added details on the customer file we generate and send to SSCL SOP to the Open API spec.

But immediately after we spotted some errors with the example data used. This change corrects those errors.