### PR TITLE
Add missing 4xx response to Open API spec

### DIFF
--- a/openapi/paths/admin/authorised_system.yml
+++ b/openapi/paths/admin/authorised_system.yml
@@ -37,6 +37,15 @@ patch:
   responses:
     '204':
       description: "Success"
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: No authorised system found with id ae181118-f17a-4eb1-b501-28bc193d7404
   requestBody:
     content:
       application/json:

--- a/openapi/paths/admin/bill_runs.yml
+++ b/openapi/paths/admin/bill_runs.yml
@@ -9,6 +9,15 @@ patch:
   responses:
     '204':
       description: "Success"
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
       description: "Failed - the bill run is not in the right state"
       content:

--- a/openapi/paths/admin/bill_runs.yml
+++ b/openapi/paths/admin/bill_runs.yml
@@ -27,3 +27,12 @@ patch:
               statusCode: 409
               error: Conflict
               message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not have a status of 'pending'.
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 422
+              error: Unprocessable Entity
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.

--- a/openapi/paths/admin/regime.yml
+++ b/openapi/paths/admin/regime.yml
@@ -27,3 +27,12 @@ get:
                 admin: 'false'
                 createdAt: '2020-12-02T09:19:22.065Z'
                 updatedAt: '2020-12-02T09:19:22.065Z'
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: No regime found with id 83562322-cb05-48cc-bc43-b06b3e5381f6

--- a/openapi/paths/admin/test/customer.yml
+++ b/openapi/paths/admin/test/customer.yml
@@ -32,3 +32,12 @@ get:
                 customerFileId: 'd04652ab-8ddb-411e-b683-53c25855f7a3'
                 createdAt: '2021-04-29T13:15:30.358Z'
                 updatedAt: '2021-04-29T13:15:30.358Z'
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: No customer file found with id 8fb7e93c-1fc7-47cd-90d5-cdb1a8a63730

--- a/openapi/paths/admin/test/transaction.yml
+++ b/openapi/paths/admin/test/transaction.yml
@@ -32,3 +32,12 @@ get:
               billRunId: 647196ac-83a8-4f5a-8436-6a2dac00b72d
               customerReference: TH230000222
               financialYear: 2018
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: No transaction found with id 323d6e4d-2703-4790-a1d5-81532d4291fd

--- a/openapi/paths/v2/bill_runs/bill_run.yml
+++ b/openapi/paths/v2/bill_runs/bill_run.yml
@@ -261,6 +261,15 @@ get:
               statusCode: 404
               error: Not found
               message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 422
+              error: Unprocessable Entity
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
 delete:
   operationId: DeleteBillRun
   description: "Deletes a specified bill run and all invoices, licences, and transactions linked to it. Bill run must be unbilled."
@@ -299,3 +308,12 @@ delete:
               statusCode: 409
               error: Conflict
               message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 has a status of 'billed'.
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 422
+              error: Unprocessable Entity
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.

--- a/openapi/paths/v2/bill_runs/bill_run.yml
+++ b/openapi/paths/v2/bill_runs/bill_run.yml
@@ -300,14 +300,14 @@ delete:
               error: Not found
               message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
-      description: "Failed - the bill run is not in the right state"
+      description: "Failed - the action conflicts with something"
       content:
         application/json:
           schema:
             example:
               statusCode: 409
               error: Conflict
-              message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 has a status of 'billed'.
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be edited because its status is billed.
     '422':
       description: "Failed - issue with the requested data"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run.yml
+++ b/openapi/paths/v2/bill_runs/bill_run.yml
@@ -243,6 +243,15 @@ get:
                           licenceNumber: 'FOOO/BARRR/306'
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
 delete:
   operationId: DeleteBillRun
   description: "Deletes a specified bill run and all invoices, licences, and transactions linked to it. Bill run must be unbilled."
@@ -254,6 +263,15 @@ delete:
   responses:
     '204':
       description: "Success"
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
       description: "Failed - the bill run is not in the right state"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run.yml
+++ b/openapi/paths/v2/bill_runs/bill_run.yml
@@ -243,6 +243,15 @@ get:
                           licenceNumber: 'FOOO/BARRR/306'
                         - id: '77502697-e274-491a-bd6d-84ec557b0485'
                           licenceNumber: 'FOOO/BARRR/307'
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '404':
       description: "Failed - unknown ID"
       content:
@@ -263,6 +272,15 @@ delete:
   responses:
     '204':
       description: "Success"
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '404':
       description: "Failed - unknown ID"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run_approve.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_approve.yml
@@ -9,6 +9,15 @@ patch:
   responses:
     '204':
       description: "Success"
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
       description: "Failed - the bill run is not in the right state"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run_approve.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_approve.yml
@@ -36,3 +36,13 @@ patch:
               statusCode: 409
               error: Conflict
               message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 does not have a status of 'generated'.
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          examples:
+            'Bill run not linked to regime':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.

--- a/openapi/paths/v2/bill_runs/bill_run_approve.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_approve.yml
@@ -28,14 +28,20 @@ patch:
               error: Not found
               message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
-      description: "Failed - the bill run is not in the right state"
+      description: "Failed - the action conflicts with something"
       content:
         application/json:
-          schema:
-            example:
-              statusCode: 409
-              error: Conflict
-              message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 does not have a status of 'generated'.
+          examples:
+            'Bill run cannot be updated':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be patched because its status is billed.
+            'Bill run is not generated':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not have a status of 'generated'.
     '422':
       description: "Failed - issue with the requested data"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run_approve.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_approve.yml
@@ -9,6 +9,15 @@ patch:
   responses:
     '204':
       description: "Success"
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '404':
       description: "Failed - unknown ID"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run_generate.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_generate.yml
@@ -9,6 +9,15 @@ patch:
   responses:
     '204':
       description: "Success"
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
       description: "Failed - the bill run is already being generated"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run_generate.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_generate.yml
@@ -9,6 +9,15 @@ patch:
   responses:
     '204':
       description: "Success"
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '404':
       description: "Failed - unknown ID"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run_generate.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_generate.yml
@@ -28,29 +28,35 @@ patch:
               error: Not found
               message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
-      description: "Failed - the bill run is already being generated"
-      content:
-        application/json:
-          schema:
-            example:
-              statusCode: 409
-              error: Conflict
-              message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is already being generated
-    '422':
-      description: "Failed - bill run cannot be generated because there is an issue with its data"
+      description: "Failed - the action conflicts with something"
       content:
         application/json:
           examples:
-            'Bill run unknown':
+            'Bill run cannot be updated':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be patched because its status is billed.
+            'Bill run is already generating':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is already being generated
+            'Bill run is already generated':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0 has already been generated.
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          examples:
+            'Bill run not linked to regime':
               value:
                 statusCode: 422
                 error: Unprocessable Entity
-                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown
-            'Invalid bill run status':
-              value:
-                statusCode: 422
-                error: Unprocessable Entity
-                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be edited because its status is billed
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
             'No transactions':
               value:
                 statusCode: 422

--- a/openapi/paths/v2/bill_runs/bill_run_send.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_send.yml
@@ -108,6 +108,15 @@ patch:
   responses:
     '204':
       description: "Success"
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
       description: "Failed - the bill run is not in the right state"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run_send.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_send.yml
@@ -136,11 +136,12 @@ patch:
               error: Conflict
               message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not have a status of 'approved'.
     '422':
-      description: "Failed - bill run cannot be sent because there is an issue with its data"
+      description: "Failed - issue with the requested data"
       content:
         application/json:
-          schema:
-            example:
-              statusCode: 422
-              error: Unprocessable Entity
-              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be sent because its status is billed
+          examples:
+            'Bill run not linked to regime':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.

--- a/openapi/paths/v2/bill_runs/bill_run_send.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_send.yml
@@ -108,6 +108,15 @@ patch:
   responses:
     '204':
       description: "Success"
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '404':
       description: "Failed - unknown ID"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run_send.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_send.yml
@@ -127,14 +127,20 @@ patch:
               error: Not found
               message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
-      description: "Failed - the bill run is not in the right state"
+      description: "Failed - the action conflicts with something"
       content:
         application/json:
-          schema:
-            example:
-              statusCode: 409
-              error: Conflict
-              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not have a status of 'approved'.
+          examples:
+            'Bill run cannot be updated':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be patched because its status is billed.
+            'Bill run is not approved':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not have a status of 'approved'.
     '422':
       description: "Failed - issue with the requested data"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run_status.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_status.yml
@@ -38,6 +38,15 @@ get:
             '08 Not billed':
               value:
                 status: 'billing_not_required'
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '404':
       description: "Failed - unknown ID"
       content:

--- a/openapi/paths/v2/bill_runs/bill_run_status.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_status.yml
@@ -56,3 +56,12 @@ get:
               statusCode: 404
               error: Not found
               message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 422
+              error: Unprocessable Entity
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.

--- a/openapi/paths/v2/bill_runs/bill_run_status.yml
+++ b/openapi/paths/v2/bill_runs/bill_run_status.yml
@@ -38,3 +38,12 @@ get:
             '08 Not billed':
               value:
                 status: 'billing_not_required'
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.

--- a/openapi/paths/v2/bill_runs/bill_runs.yml
+++ b/openapi/paths/v2/bill_runs/bill_runs.yml
@@ -26,10 +26,15 @@ post:
               error: Forbidden
               message: Unauthorised for regime 'wrls'
     '422':
-      description: "Failed - bill run cannot be generated because there is an issue with its data"
+      description: "Failed - issue with the requested data"
       content:
         application/json:
           examples:
+            'Bill run not linked to regime':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
             'Missing region':
               value:
                 statusCode: 422

--- a/openapi/paths/v2/bill_runs/bill_runs.yml
+++ b/openapi/paths/v2/bill_runs/bill_runs.yml
@@ -16,6 +16,15 @@ post:
             billRun:
               id: '2bbbe459-966e-4026-b5d2-2f10867bdddd'
               billRunNumber: 10004
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '422':
       description: "Failed - bill run cannot be generated because there is an issue with its data"
       content:

--- a/openapi/paths/v2/bill_runs/invoices/invoice.yml
+++ b/openapi/paths/v2/bill_runs/invoices/invoice.yml
@@ -73,6 +73,15 @@ get:
                       s130Agreement:
                       eiucSourceFactor: 0
                       eiucFactor: 0
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '404':
       description: "Failed - unknown ID"
       content:
@@ -110,3 +119,27 @@ delete:
   responses:
     '204':
       description: "Success"
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          examples:
+            'Bill run unknown':
+              value:
+                statusCode: 404
+                error: Not found
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+            'Invoice unknown':
+              value:
+                statusCode: 404
+                error: Not found
+                message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.

--- a/openapi/paths/v2/bill_runs/invoices/invoice.yml
+++ b/openapi/paths/v2/bill_runs/invoices/invoice.yml
@@ -152,6 +152,15 @@ delete:
                 statusCode: 404
                 error: Not found
                 message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
+    '409':
+      description: "Failed - the action conflicts with something"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 409
+              error: Conflict
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be edited because its status is billed.
     '422':
       description: "Failed - issue with the requested data"
       content:

--- a/openapi/paths/v2/bill_runs/invoices/invoice.yml
+++ b/openapi/paths/v2/bill_runs/invoices/invoice.yml
@@ -74,14 +74,20 @@ get:
                       eiucSourceFactor: 0
                       eiucFactor: 0
     '404':
-      description: "Failed - the invoice is unknown"
+      description: "Failed - unknown ID"
       content:
         application/json:
-          schema:
-            example:
-              statusCode: 404
-              error: Not found
-              message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
+          examples:
+            'Bill run unknown':
+              value:
+                statusCode: 404
+                error: Not found
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+            'Invoice unknown':
+              value:
+                statusCode: 404
+                error: Not found
+                message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
     '409':
       description: "Failed - the invoice is not linked to that bill run"
       content:

--- a/openapi/paths/v2/bill_runs/invoices/invoice.yml
+++ b/openapi/paths/v2/bill_runs/invoices/invoice.yml
@@ -106,7 +106,16 @@ get:
               statusCode: 409
               error: Conflict
               message: Invoice db82bf38-638a-44d3-b1b3-1ae8524d9c38 is not linked to bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9.
-
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          examples:
+            'Bill run not linked to regime':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
 delete:
   operationId: DeleteBillRunInvoice
   description: "Delete the specified invoice and all linked licences and transactions. As part of the deletion the linked bill run will be updated."
@@ -143,3 +152,13 @@ delete:
                 statusCode: 404
                 error: Not found
                 message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          examples:
+            'Bill run not linked to regime':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.

--- a/openapi/paths/v2/bill_runs/invoices/invoice_rebill.yml
+++ b/openapi/paths/v2/bill_runs/invoices/invoice_rebill.yml
@@ -20,6 +20,21 @@ patch:
               rebilledType: C
             - id: db82bf38-638a-44d3-b1b3-1ae8524d9c38
               rebilledType: R
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          examples:
+            'Bill run unknown':
+              value:
+                statusCode: 404
+                error: Not found
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+            'Invoice unknown':
+              value:
+                statusCode: 404
+                error: Not found
+                message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
     '409':
       description: "Failed - the invoice has already been rebilled"
       content:

--- a/openapi/paths/v2/bill_runs/invoices/invoice_rebill.yml
+++ b/openapi/paths/v2/bill_runs/invoices/invoice_rebill.yml
@@ -20,6 +20,15 @@ patch:
               rebilledType: C
             - id: db82bf38-638a-44d3-b1b3-1ae8524d9c38
               rebilledType: R
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '404':
       description: "Failed - unknown ID"
       content:

--- a/openapi/paths/v2/bill_runs/invoices/invoice_rebill.yml
+++ b/openapi/paths/v2/bill_runs/invoices/invoice_rebill.yml
@@ -69,3 +69,13 @@ patch:
                 statusCode: 409
                 error: Conflict
                 message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is for region T but bill run aa630ae0-0e51-4166-9025-66576c513f7f is for region A.
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          examples:
+            'Bill run not linked to regime':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.

--- a/openapi/paths/v2/bill_runs/licences/licence.yml
+++ b/openapi/paths/v2/bill_runs/licences/licence.yml
@@ -34,6 +34,15 @@ delete:
                 statusCode: 404
                 error: Not found
                 message: Licence 458d2739-6ae6-4919-ac12-5536589d3af9 is unknown.
+    '409':
+      description: "Failed - the action conflicts with something"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 409
+              error: Conflict
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be edited because its status is billed.
     '422':
       description: "Failed - issue with the requested data"
       content:

--- a/openapi/paths/v2/bill_runs/licences/licence.yml
+++ b/openapi/paths/v2/bill_runs/licences/licence.yml
@@ -34,3 +34,13 @@ delete:
                 statusCode: 404
                 error: Not found
                 message: Licence 458d2739-6ae6-4919-ac12-5536589d3af9 is unknown.
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          examples:
+            'Bill run not linked to regime':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.

--- a/openapi/paths/v2/bill_runs/licences/licence.yml
+++ b/openapi/paths/v2/bill_runs/licences/licence.yml
@@ -10,3 +10,18 @@ delete:
   responses:
     '204':
       description: "Success"
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          examples:
+            'Bill run unknown':
+              value:
+                statusCode: 404
+                error: Not found
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+            'Licence unknown':
+              value:
+                statusCode: 404
+                error: Not found
+                message: Licence 458d2739-6ae6-4919-ac12-5536589d3af9 is unknown.

--- a/openapi/paths/v2/bill_runs/licences/licence.yml
+++ b/openapi/paths/v2/bill_runs/licences/licence.yml
@@ -10,6 +10,15 @@ delete:
   responses:
     '204':
       description: "Success"
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '404':
       description: "Failed - unknown ID"
       content:

--- a/openapi/paths/v2/bill_runs/transactions/bill_run_transactions.yml
+++ b/openapi/paths/v2/bill_runs/transactions/bill_run_transactions.yml
@@ -36,15 +36,21 @@ post:
               error: Not found
               message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
-      description: "Failed - Transaction cannot be added because Client ID already exists"
+      description: "Failed - the action conflicts with something"
       content:
         application/json:
-          schema:
-            example:
-              statusCode: 409
-              error: 'Conflict'
-              message: "A transaction with Client ID '2395429b-e703-43bc-8522-ce3f67507ffa' for Regime 'wrls' already exists."
-              clientId: '2395429b-e703-43bc-8522-ce3f67507ffa'
+          examples:
+            'Bill run cannot be changed':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be edited because its status is billed.
+            'Client ID matches existing transaction':
+              value:
+                statusCode: 409
+                error: Conflict
+                message: A transaction with Client ID '2395429b-e703-43bc-8522-ce3f67507ffa' for Regime 'wrls' already exists.
+                clientId: 2395429b-e703-43bc-8522-ce3f67507ff
     '422':
       description: "Failed - issue with the requested data"
       content:

--- a/openapi/paths/v2/bill_runs/transactions/bill_run_transactions.yml
+++ b/openapi/paths/v2/bill_runs/transactions/bill_run_transactions.yml
@@ -17,6 +17,15 @@ post:
             transaction:
               id: 'fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3'
               clientId: '2395429b-e703-43bc-8522-ce3f67507ffa'
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
     '404':
       description: "Failed - unknown ID"
       content:

--- a/openapi/paths/v2/bill_runs/transactions/bill_run_transactions.yml
+++ b/openapi/paths/v2/bill_runs/transactions/bill_run_transactions.yml
@@ -45,6 +45,16 @@ post:
               error: 'Conflict'
               message: "A transaction with Client ID '2395429b-e703-43bc-8522-ce3f67507ffa' for Regime 'wrls' already exists."
               clientId: '2395429b-e703-43bc-8522-ce3f67507ffa'
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          examples:
+            'Bill run not linked to regime':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
   requestBody:
     content:
       application/json:

--- a/openapi/paths/v2/bill_runs/transactions/bill_run_transactions.yml
+++ b/openapi/paths/v2/bill_runs/transactions/bill_run_transactions.yml
@@ -17,6 +17,15 @@ post:
             transaction:
               id: 'fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3'
               clientId: '2395429b-e703-43bc-8522-ce3f67507ffa'
+    '404':
+      description: "Failed - unknown ID"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 404
+              error: Not found
+              message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
     '409':
       description: "Failed - Transaction cannot be added because Client ID already exists"
       content:

--- a/openapi/paths/v2/bill_runs/transactions/bill_run_transactions.yml
+++ b/openapi/paths/v2/bill_runs/transactions/bill_run_transactions.yml
@@ -17,6 +17,21 @@ post:
             transaction:
               id: 'fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3'
               clientId: '2395429b-e703-43bc-8522-ce3f67507ffa'
+    '400':
+      description: "Failed - issue with the Rules Service"
+      content:
+        application/json:
+          examples:
+            'Cannot connect to rules service':
+              value:
+                statusCode: 400
+                error: Bad Request
+                message: "Error communicating with the rules service: [error code]"
+            'Rule service returned a 5xx':
+              value:
+                statusCode: 400
+                error: Bad Request
+                message: "Rules service error: [error message]"
     '403':
       description: "Failed - not authorised"
       content:
@@ -61,6 +76,21 @@ post:
                 statusCode: 422
                 error: Unprocessable Entity
                 message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
+            'Ruleset not found':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: Ruleset not found, please check periodStart value.
+            'Rule service data error':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: "Rules service error: [error message]"
+            'Rule service data message':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: "Rules service returned the following: [message]"
   requestBody:
     content:
       application/json:

--- a/openapi/paths/v2/calculate_charge/calculate_charge.yml
+++ b/openapi/paths/v2/calculate_charge/calculate_charge.yml
@@ -23,6 +23,21 @@ post:
               eiucSourceFactor: 0
               eiuc: 0
               suc: 1495
+    '400':
+      description: "Failed - issue with the Rules Service"
+      content:
+        application/json:
+          examples:
+            'Cannot connect to rules service':
+              value:
+                statusCode: 400
+                error: Bad Request
+                message: "Error communicating with the rules service: [error code]"
+            'Rule service returned a 5xx':
+              value:
+                statusCode: 400
+                error: Bad Request
+                message: "Rules service error: [error message]"
     '403':
       description: "Failed - not authorised"
       content:
@@ -32,6 +47,26 @@ post:
               statusCode: 403
               error: Forbidden
               message: Unauthorised for regime 'wrls'
+    '422':
+      description: "Failed - issue with the requested data"
+      content:
+        application/json:
+          examples:
+            'Ruleset not found':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: Ruleset not found, please check periodStart value.
+            'Rule service data error':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: "Rules service error: [error message]"
+            'Rule service data message':
+              value:
+                statusCode: 422
+                error: Unprocessable Entity
+                message: "Rules service returned the following: [message]"
   requestBody:
     content:
       application/json:

--- a/openapi/paths/v2/calculate_charge/calculate_charge.yml
+++ b/openapi/paths/v2/calculate_charge/calculate_charge.yml
@@ -23,6 +23,15 @@ post:
               eiucSourceFactor: 0
               eiuc: 0
               suc: 1495
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
   requestBody:
     content:
       application/json:

--- a/openapi/paths/v2/customer_changes/customer_changes.yml
+++ b/openapi/paths/v2/customer_changes/customer_changes.yml
@@ -74,6 +74,15 @@ post:
   responses:
     '201':
       description: Success
+    '403':
+      description: "Failed - not authorised"
+      content:
+        application/json:
+          schema:
+            example:
+              statusCode: 403
+              error: Forbidden
+              message: Unauthorised for regime 'wrls'
   requestBody:
     content:
       application/json:

--- a/openapi/versions/draft.yml
+++ b/openapi/versions/draft.yml
@@ -351,6 +351,15 @@ paths:
                   admin: 'false'
                   createdAt: '2020-12-02T09:19:22.065Z'
                   updatedAt: '2020-12-02T09:19:22.065Z'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: No regime found with id 83562322-cb05-48cc-bc43-b06b3e5381f6
   "/admin/authorised-systems":
     get:
       operationId: ListAuthorisedSystems
@@ -719,6 +728,15 @@ paths:
       responses:
         '204':
           description: Success
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: No authorised system found with id ae181118-f17a-4eb1-b501-28bc193d7404
       requestBody:
         content:
           application/json:
@@ -799,6 +817,15 @@ paths:
       responses:
         '204':
           description: Success
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
         '409':
           description: Failed - the bill run is not in the right state
           content:
@@ -809,6 +836,16 @@ paths:
                   error: Conflict
                   message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not
                     have a status of 'pending'.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 422
+                  error: Unprocessable Entity
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked
+                    to regime wrls.
   "/admin/{regime}/customers":
     patch:
       operationId: SendCustomer
@@ -1183,6 +1220,15 @@ paths:
                   customerFileId: d04652ab-8ddb-411e-b683-53c25855f7a3
                   createdAt: '2021-04-29T13:15:30.358Z'
                   updatedAt: '2021-04-29T13:15:30.358Z'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: No customer file found with id 8fb7e93c-1fc7-47cd-90d5-cdb1a8a63730
   "/admin/test/transaction/{transactionId}":
     get:
       operationId: ViewTestTransaction
@@ -1228,6 +1274,15 @@ paths:
                   billRunId: 647196ac-83a8-4f5a-8436-6a2dac00b72d
                   customerReference: TH230000222
                   financialYear: 2018
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: No transaction found with id 323d6e4d-2703-4790-a1d5-81532d4291fd
   "/v2/{regime}/bill-runs":
     post:
       operationId: CreateBillRun
@@ -1279,12 +1334,26 @@ paths:
                 billRun:
                   id: 2bbbe459-966e-4026-b5d2-2f10867bdddd
                   billRunNumber: 10004
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
         '422':
-          description: Failed - bill run cannot be generated because there is an issue
-            with its data
+          description: Failed - issue with the requested data
           content:
             application/json:
               examples:
+                Bill run not linked to regime:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
+                      linked to regime wrls.
                 Missing region:
                   value:
                     statusCode: 422
@@ -1381,18 +1450,83 @@ paths:
                 transaction:
                   id: fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3
                   clientId: 2395429b-e703-43bc-8522-ce3f67507ffa
-        '409':
-          description: Failed - Transaction cannot be added because Client ID already
-            exists
+        '400':
+          description: Failed - issue with the Rules Service
+          content:
+            application/json:
+              examples:
+                Cannot connect to rules service:
+                  value:
+                    statusCode: 400
+                    error: Bad Request
+                    message: 'Error communicating with the rules service: [error code]'
+                Rule service returned a 5xx:
+                  value:
+                    statusCode: 400
+                    error: Bad Request
+                    message: 'Rules service error: [error message]'
+        '403':
+          description: Failed - not authorised
           content:
             application/json:
               schema:
                 example:
-                  statusCode: 409
-                  error: Conflict
-                  message: A transaction with Client ID '2395429b-e703-43bc-8522-ce3f67507ffa'
-                    for Regime 'wrls' already exists.
-                  clientId: 2395429b-e703-43bc-8522-ce3f67507ffa
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+        '409':
+          description: Failed - the action conflicts with something
+          content:
+            application/json:
+              examples:
+                Bill run cannot be changed:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot
+                      be edited because its status is billed.
+                Client ID matches existing transaction:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: A transaction with Client ID '2395429b-e703-43bc-8522-ce3f67507ffa'
+                      for Regime 'wrls' already exists.
+                    clientId: 2395429b-e703-43bc-8522-ce3f67507ff
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              examples:
+                Bill run not linked to regime:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
+                      linked to regime wrls.
+                Ruleset not found:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Ruleset not found, please check periodStart value.
+                Rule service data error:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: 'Rules service error: [error message]'
+                Rule service data message:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: 'Rules service returned the following: [message]'
       requestBody:
         content:
           application/json:
@@ -2078,6 +2212,34 @@ paths:
                           licenceNumber: FOOO/BARRR/306
                         - id: 77502697-e274-491a-bd6d-84ec557b0485
                           licenceNumber: FOOO/BARRR/307
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 422
+                  error: Unprocessable Entity
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked
+                    to regime wrls.
     delete:
       operationId: DeleteBillRun
       description: Deletes a specified bill run and all invoices, licences, and transactions
@@ -2113,16 +2275,44 @@ paths:
       responses:
         '204':
           description: Success
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
         '409':
-          description: Failed - the bill run is not in the right state
+          description: Failed - the action conflicts with something
           content:
             application/json:
               schema:
                 example:
                   statusCode: 409
                   error: Conflict
-                  message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 has a status
-                    of 'billed'.
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be
+                    edited because its status is billed.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 422
+                  error: Unprocessable Entity
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked
+                    to regime wrls.
   "/v2/{regime}/bill-runs/{billRunId}/generate":
     patch:
       operationId: GenerateBillRun
@@ -2159,33 +2349,58 @@ paths:
       responses:
         '204':
           description: Success
-        '409':
-          description: Failed - the bill run is already being generated
+        '403':
+          description: Failed - not authorised
           content:
             application/json:
               schema:
                 example:
-                  statusCode: 409
-                  error: Conflict
-                  message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0
-                    is already being generated
-        '422':
-          description: Failed - bill run cannot be generated because there is an issue
-            with its data
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+        '409':
+          description: Failed - the action conflicts with something
           content:
             application/json:
               examples:
-                Bill run unknown:
+                Bill run cannot be updated:
                   value:
-                    statusCode: 422
-                    error: Unprocessable Entity
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown
-                Invalid bill run status:
-                  value:
-                    statusCode: 422
-                    error: Unprocessable Entity
+                    statusCode: 409
+                    error: Conflict
                     message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot
-                      be edited because its status is billed
+                      be patched because its status is billed.
+                Bill run is already generating:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0
+                      is already being generated
+                Bill run is already generated:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0
+                      has already been generated.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              examples:
+                Bill run not linked to regime:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
+                      linked to regime wrls.
                 No transactions:
                   value:
                     statusCode: 422
@@ -2273,6 +2488,34 @@ paths:
                 '08 Not billed':
                   value:
                     status: billing_not_required
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 422
+                  error: Unprocessable Entity
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked
+                    to regime wrls.
   "/v2/{regime}/bill-runs/{billRunId}/approve":
     patch:
       operationId: ApproveBillRun
@@ -2309,16 +2552,52 @@ paths:
       responses:
         '204':
           description: Success
-        '409':
-          description: Failed - the bill run is not in the right state
+        '403':
+          description: Failed - not authorised
           content:
             application/json:
               schema:
                 example:
-                  statusCode: 409
-                  error: Conflict
-                  message: Bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9 does not
-                    have a status of 'generated'.
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+        '409':
+          description: Failed - the action conflicts with something
+          content:
+            application/json:
+              examples:
+                Bill run cannot be updated:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot
+                      be patched because its status is billed.
+                Bill run is not generated:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not
+                      have a status of 'generated'.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              examples:
+                Bill run not linked to regime:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
+                      linked to regime wrls.
   "/v2/{regime}/bill-runs/{billRunId}/send":
     patch:
       operationId: SendBillRun
@@ -2452,27 +2731,52 @@ paths:
       responses:
         '204':
           description: Success
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 404
+                  error: Not found
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
         '409':
-          description: Failed - the bill run is not in the right state
+          description: Failed - the action conflicts with something
           content:
             application/json:
-              schema:
-                example:
-                  statusCode: 409
-                  error: Conflict
-                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not
-                    have a status of 'approved'.
+              examples:
+                Bill run cannot be updated:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot
+                      be patched because its status is billed.
+                Bill run is not approved:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not
+                      have a status of 'approved'.
         '422':
-          description: Failed - bill run cannot be sent because there is an issue
-            with its data
+          description: Failed - issue with the requested data
           content:
             application/json:
-              schema:
-                example:
-                  statusCode: 422
-                  error: Unprocessable Entity
-                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be
-                    sent because its status is billed
+              examples:
+                Bill run not linked to regime:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
+                      linked to regime wrls.
   "/v2/{regime}/bill-runs/{billRunId}/invoices/{invoiceId}":
     get:
       operationId: ViewBillRunInvoice
@@ -2728,15 +3032,30 @@ paths:
                           s130Agreement:
                           eiucSourceFactor: 0
                           eiucFactor: 0
-        '404':
-          description: Failed - the invoice is unknown
+        '403':
+          description: Failed - not authorised
           content:
             application/json:
               schema:
                 example:
-                  statusCode: 404
-                  error: Not found
-                  message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              examples:
+                Bill run unknown:
+                  value:
+                    statusCode: 404
+                    error: Not found
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+                Invoice unknown:
+                  value:
+                    statusCode: 404
+                    error: Not found
+                    message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
         '409':
           description: Failed - the invoice is not linked to that bill run
           content:
@@ -2747,6 +3066,17 @@ paths:
                   error: Conflict
                   message: Invoice db82bf38-638a-44d3-b1b3-1ae8524d9c38 is not linked
                     to bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              examples:
+                Bill run not linked to regime:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
+                      linked to regime wrls.
     delete:
       operationId: DeleteBillRunInvoice
       description: Delete the specified invoice and all linked licences and transactions.
@@ -2791,6 +3121,51 @@ paths:
       responses:
         '204':
           description: Success
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              examples:
+                Bill run unknown:
+                  value:
+                    statusCode: 404
+                    error: Not found
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+                Invoice unknown:
+                  value:
+                    statusCode: 404
+                    error: Not found
+                    message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
+        '409':
+          description: Failed - the action conflicts with something
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 409
+                  error: Conflict
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be
+                    edited because its status is billed.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              examples:
+                Bill run not linked to regime:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
+                      linked to regime wrls.
   "/v2/{regime}/calculate-charge":
     post:
       operationId: CalculateCharge
@@ -2881,6 +3256,50 @@ paths:
                   eiucSourceFactor: 0
                   eiuc: 0
                   suc: 1495
+        '400':
+          description: Failed - issue with the Rules Service
+          content:
+            application/json:
+              examples:
+                Cannot connect to rules service:
+                  value:
+                    statusCode: 400
+                    error: Bad Request
+                    message: 'Error communicating with the rules service: [error code]'
+                Rule service returned a 5xx:
+                  value:
+                    statusCode: 400
+                    error: Bad Request
+                    message: 'Rules service error: [error message]'
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              examples:
+                Ruleset not found:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Ruleset not found, please check periodStart value.
+                Rule service data error:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: 'Rules service error: [error message]'
+                Rule service data message:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: 'Rules service returned the following: [message]'
       requestBody:
         content:
           application/json:
@@ -3120,6 +3539,15 @@ paths:
       responses:
         '201':
           description: Success
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
       requestBody:
         content:
           application/json:
@@ -3283,6 +3711,30 @@ paths:
                   rebilledType: C
                 - id: db82bf38-638a-44d3-b1b3-1ae8524d9c38
                   rebilledType: R
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              examples:
+                Bill run unknown:
+                  value:
+                    statusCode: 404
+                    error: Not found
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+                Invoice unknown:
+                  value:
+                    statusCode: 404
+                    error: Not found
+                    message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
         '409':
           description: Failed - the invoice has already been rebilled
           content:
@@ -3313,6 +3765,17 @@ paths:
                     message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is for
                       region T but bill run aa630ae0-0e51-4166-9025-66576c513f7f is
                       for region A.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              examples:
+                Bill run not linked to regime:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
+                      linked to regime wrls.
   "/v2/{regime}/bill-runs/{billRunId}/licences/{licenceId}":
     delete:
       operationId: DeleteBillRunLicence
@@ -3358,6 +3821,51 @@ paths:
       responses:
         '204':
           description: Success
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              examples:
+                Bill run unknown:
+                  value:
+                    statusCode: 404
+                    error: Not found
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+                Licence unknown:
+                  value:
+                    statusCode: 404
+                    error: Not found
+                    message: Licence 458d2739-6ae6-4919-ac12-5536589d3af9 is unknown.
+        '409':
+          description: Failed - the action conflicts with something
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 409
+                  error: Conflict
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be
+                    edited because its status is billed.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              examples:
+                Bill run not linked to regime:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
+                      linked to regime wrls.
 security:
 - OAuth2: []
 components:


### PR DESCRIPTION
We have some examples of the `4xx` responses the [SROC Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) might return but it's not complete.

There are some shared responses, for example, when the bill run is unknown that are not included which we feel are needed to make the spec complete.

So, this change goes through the endpoints adding any missing `4xx` responses we are aware of.