### PR TITLE
Team name change!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SROC Service team
+# Charging Module Team
 
-A team of rocking 🎸 folk dedicated to supporting all the things **Strategic Review of Charging**!
+A team of rocking 🎸 folk dedicated to supporting all the things **charging**!
 
 This acts as a repo of guides and documents specific to the team, plus it's where we manage our list of issues rather than trying to manage them in individual projects.
 

--- a/dockerhub/README.md
+++ b/dockerhub/README.md
@@ -44,9 +44,9 @@ volumes:
   cma_api_db_volume:
 ```
 
-You will need to create a [.env file](https://docs.docker.com/compose/env-file/) with the correct values before you first attempt to build the environment. The project's repo has an [example](https://github.com/DEFRA/sroc-charging-module-api/blob/main/.env.example). But you will need to contact the SROC delivery team to obtain the necessary credentials you'll need to actually make it work.
+You will need to create a [.env file](https://docs.docker.com/compose/env-file/) with the correct values before you first attempt to build the environment. The project's repo has an [example](https://github.com/DEFRA/sroc-charging-module-api/blob/main/.env.example). But you will need to contact the Charging Module team to obtain the necessary credentials you'll need to actually make it work.
 
-> ***NEVER*** commit the `.env` to source control. The credentials the SROC delivery team provide _must_ remain secret.
+> ***NEVER*** commit the `.env` to source control. The credentials the Charging Module team provide _must_ remain secret.
 
 With the `.env` file in place, you can tell compose to grab the images and start the environment for the first time with `docker-compose up`.
 
@@ -106,7 +106,7 @@ The environment should now be ready to use.
 
 ## Authentication
 
-With the `.env` provided by the SROC team, and having run `make seed` the authorised systems (users) you'll need to access the API will automatically have been created.
+With the `.env` provided by the Charging Module team, and having run `make seed` the authorised systems (users) you'll need to access the API will automatically have been created.
 
 We encourage all users of this API to check out our [JSON Web Keys readme](https://github.com/DEFRA/sroc-charging-module-api/tree/main/keys) which goes into detail about how requests are authenticated.
 

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -81,20 +81,20 @@ info:
 
     ### Talking to INTEGRATION
 
-    We have an AWS `INTEGRATION` environment setup and available specifically for client systems to use. For access contact the [SROC Service Team](alan.cruikshanks@defra.gov.uk).
+    We have an AWS `INTEGRATION` environment setup and available specifically for client systems to use. For access contact the [Charging Module team](alan.cruikshanks@defra.gov.uk).
 
     ### Running the API locally
 
-    The [SROC service team](https://github.com/DEFRA/sroc-service-team) also provide a [Docker image](https://hub.docker.com/r/environmentagency/sroc-charging-module-api) you can use to run the API locally. Checkout out their [docs](https://github.com/DEFRA/sroc-service-team/tree/main/dockerhub) for info on how to get it up and running locally.
+    The [Charging Module team](https://github.com/DEFRA/sroc-service-team) also provide a [Docker image](https://hub.docker.com/r/environmentagency/sroc-charging-module-api) you can use to run the API locally. Checkout out their [docs](https://github.com/DEFRA/sroc-service-team/tree/main/dockerhub) for info on how to get it up and running locally.
 
     ### Talking to the API
 
-    The **SROC service team** use [Postman](https://www.postman.com/) as the means to interact with the API. Check out their [docs](https://github.com/DEFRA/sroc-service-team/postman) for info on how to go about setting up your own Postman environment.
+    The **Charging Module team** use [Postman](https://www.postman.com/) as the means to interact with the API. Check out their [docs](https://github.com/DEFRA/sroc-service-team/postman) for info on how to go about setting up your own Postman environment.
 
   version: "draft"
   title: SROC Charging Module API
   contact:
-    name: SROC Service Team
+    name: Charging Module team
     email: alan.cruikshanks@defra.gov.uk
     url: 'https://github.com/DEFRA/sroc-service-team'
   license:

--- a/openapi/versions/draft.yml
+++ b/openapi/versions/draft.yml
@@ -81,19 +81,19 @@ info:
 
     ### Talking to INTEGRATION
 
-    We have an AWS `INTEGRATION` environment setup and available specifically for client systems to use. For access contact the [SROC Service Team](alan.cruikshanks@defra.gov.uk).
+    We have an AWS `INTEGRATION` environment setup and available specifically for client systems to use. For access contact the [Charging Module team](alan.cruikshanks@defra.gov.uk).
 
     ### Running the API locally
 
-    The [SROC service team](https://github.com/DEFRA/sroc-service-team) also provide a [Docker image](https://hub.docker.com/r/environmentagency/sroc-charging-module-api) you can use to run the API locally. Checkout out their [docs](https://github.com/DEFRA/sroc-service-team/tree/main/dockerhub) for info on how to get it up and running locally.
+    The [Charging Module team](https://github.com/DEFRA/sroc-service-team) also provide a [Docker image](https://hub.docker.com/r/environmentagency/sroc-charging-module-api) you can use to run the API locally. Checkout out their [docs](https://github.com/DEFRA/sroc-service-team/tree/main/dockerhub) for info on how to get it up and running locally.
 
     ### Talking to the API
 
-    The **SROC service team** use [Postman](https://www.postman.com/) as the means to interact with the API. Check out their [docs](https://github.com/DEFRA/sroc-service-team/postman) for info on how to go about setting up your own Postman environment.
+    The **Charging Module team** use [Postman](https://www.postman.com/) as the means to interact with the API. Check out their [docs](https://github.com/DEFRA/sroc-service-team/postman) for info on how to go about setting up your own Postman environment.
   version: draft
   title: SROC Charging Module API
   contact:
-    name: SROC Service Team
+    name: Charging Module team
     email: alan.cruikshanks@defra.gov.uk
     url: https://github.com/DEFRA/sroc-service-team
   license:

--- a/releasing/cha.md
+++ b/releasing/cha.md
@@ -1,6 +1,6 @@
 # Release process
 
-This covers the release process for the [SROC Charging Module API](https://github.com/DEFRA/sroc-charging-module-api).
+This covers the release process for the [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api).
 
 It covers
 
@@ -157,7 +157,7 @@ Do **not** click the *Build Now* button! That comes later 😁
 
 > At this time the WRLS team is our only client system!
 
-Create an email with approximately the following format and send to the client service's development and test team leads. In `CC` add from the SROC team
+Create an email with approximately the following format and send to the client service's development and test team leads. In `CC` add from the Charging Module team
 
 - project manager
 - test manager
@@ -165,11 +165,11 @@ Create an email with approximately the following format and send to the client s
 - dev team
 
 ```text
-Subject: SROC Charging Module API - v0.8.1 ready for release to INTEGRATION
+Subject: Charging Module API - v0.8.1 ready for release to INTEGRATION
 
 Hello
 
-This is to let you know we are ready to release v0.8.1 of the SROC Charging Module API to the INTEGRATION environment.
+This is to let you know we are ready to release v0.8.1 of the Charging Module API to the INTEGRATION environment.
 
 The CHANGELOG for v0.8.1 is below. You can find the full CHANGELOG at https://github.com/DEFRA/sroc-charging-module-api/blob/master/CHANGELOG.md
 
@@ -182,7 +182,7 @@ We just need to confirm with you a suitable date and time to update the environm
 
 #### Create INT calendar appointment
 
-Once a date and time has been agreed create a calendar appointment with approximately the following format in your Defra Outlook. Invite the client service's development and test team leads. In `optional` add from the SROC team
+Once a date and time has been agreed create a calendar appointment with approximately the following format in your Defra Outlook. Invite the client service's development and test team leads. In `optional` add from the Charging Module team
 
 - project manager
 - test manager
@@ -190,11 +190,11 @@ Once a date and time has been agreed create a calendar appointment with approxim
 - dev team
 
 ```text
-Title: SROC Charging Module API - Release v0.8.1 to INTEGRATION
+Title: Charging Module API - Release v0.8.1 to INTEGRATION
 
 No actual meeting will take place!
 
-This is just a reminder to all that the SROC Charging Module API INTEGRATION environment will be updated at this time.
+This is just a reminder to all that the Charging Module API INTEGRATION environment will be updated at this time.
 ```
 
 This will serve as both a confirmation and reminder to all of the agreed date and time.
@@ -205,7 +205,7 @@ At the agreed time and date, find the `INT_01_CHA_DEPLOY` job in the Jenkins ins
 
 #### Send INT release done email to clients
 
-Create an email with approximately the following format and send to the client service's development and test team leads. In `CC` add from the SROC team
+Create an email with approximately the following format and send to the client service's development and test team leads. In `CC` add from the Charging Module team
 
 - project manager
 - test manager
@@ -213,11 +213,11 @@ Create an email with approximately the following format and send to the client s
 - dev team
 
 ```text
-Subject: SROC Charging Module API - v0.8.1 released to INTEGRATION
+Subject: Charging Module API - v0.8.1 released to INTEGRATION
 
 Hello
 
-This is to let you know that v0.8.1 of the SROC Charging Module API has been released to the INTEGRATION environment.
+This is to let you know that v0.8.1 of the Charging Module API has been released to the INTEGRATION environment.
 
 Any issues or questions please let us know.
 
@@ -294,14 +294,14 @@ There are plenty of existing ones to base it on covering a number of different t
 
 ### Create calendar appointment
 
-Once a date and time has been agreed create a calendar appointment with approximately the following format in your Defra Outlook. Invite the appointed web-ops and test analyst carrying out the release. In `optional` add from the SROC team
+Once a date and time has been agreed create a calendar appointment with approximately the following format in your Defra Outlook. Invite the appointed web-ops and test analyst carrying out the release. In `optional` add from the Charging Module team
 
 - project manager
 - test manager
 - dev team
 
 ```text
-title: SROC Charging Module API - Release [version] to PRODUCTION
+title: Charging Module API - Release [version] to PRODUCTION
 
 [Copy of release note content]
 
@@ -324,7 +324,7 @@ Once web-ops confirm the changes have been applied, the test analyst will perfor
 
 ### Confirm release successful
 
-Create an email with approximately the following format and send to **SM-Defra-Change Management**. In `CC` add web-ops lead plus from the SROC team
+Create an email with approximately the following format and send to **SM-Defra-Change Management**. In `CC` add web-ops lead plus from the Charging Module team
 
 - project manager
 - test manager
@@ -336,7 +336,7 @@ Subject: [RfC reference] completed successfully
 
 Hello
 
-This is to let you know [RfC reference] for the SROC Charging Module API was completed successfully.
+This is to let you know [RfC reference] for the Charging Module API was completed successfully.
 
 [Sign off]
 ```

--- a/releasing/tcm.md
+++ b/releasing/tcm.md
@@ -1,6 +1,6 @@
 # TCM
 
-This covers the release process for the [SROC Tactical Charging Module](https://github.com/DEFRA/sroc-tcm-admin).
+This covers the release process for the [Tactical Charging Module](https://github.com/DEFRA/sroc-tcm-admin).
 
 It covers
 
@@ -181,14 +181,14 @@ There are plenty of existing ones to base it on covering a number of different t
 
 ### Create calendar appointment
 
-Once a date and time has been agreed create a calendar appointment with approximately the following format in your Defra Outlook. Invite the appointed web-ops and test analyst carrying out the release. In `optional` add from the SROC team
+Once a date and time has been agreed create a calendar appointment with approximately the following format in your Defra Outlook. Invite the appointed web-ops and test analyst carrying out the release. In `optional` add from the Charging Module team
 
 - project manager
 - test manager
 - dev team
 
 ```text
-title: SROC TCM Admin - Release [version] to PRODUCTION
+title: Tactical Charging Module - Release [version] to PRODUCTION
 
 [Copy of release note content]
 
@@ -211,7 +211,7 @@ Once web-ops confirm the changes have been applied, the test analyst will perfor
 
 ### Confirm release successful
 
-Create an email with approximately the following format and send to **SM-Defra-Change Management**. In `CC` add web-ops lead plus from the SROC team
+Create an email with approximately the following format and send to **SM-Defra-Change Management**. In `CC` add web-ops lead plus from the Charging Module team
 
 - project manager
 - test manager
@@ -223,7 +223,7 @@ Subject: [RfC reference] completed successfully
 
 Hello
 
-This is to let you know [RfC reference] for the SROC TCM Admin service was completed successfully.
+This is to let you know [RfC reference] for the Tactical Charging Module service was completed successfully.
 
 [Sign off]
 ```

--- a/services/README.md
+++ b/services/README.md
@@ -1,3 +1,3 @@
 # Services
 
-> TBD - We intend to write a script which will pull all the code related to SROC into this folder to help new members get up and running quickly. As yet that script is still to be written.
+> TBD - We intend to write a script which will pull all the code related to Charging into this folder to help new members get up and running quickly. As yet that script is still to be written.


### PR DESCRIPTION
Having finally shipped the initial [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api) which currently is only used by the WRLS team, we're thinking ahead to working with other services on things other than SROC.

With that in mind, we have officially (ish) renamed ourselves.

- the service we look after shall be henceforth known as **Charging Module** (made up of the TCM, CM, and Rules Service)
- we shall be henceforth known as the **Charging Module Team**
- we shall no longer use the prefix **SROC** on everything

This change just updates the root README and any other obvious references. In the future, we'll do the harder task of updating our repo names and anything we find that links to them.