### PR TITLE
Fix CHA OpenAPI spec test customer files endpoint

### DIFF
--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -171,10 +171,10 @@ paths:
   '/admin/test/{regime}/bill-runs':
     $ref: 'paths/admin/test/bill_runs.yml'
 
-  '/admin/test/{regime}/customers':
+  '/admin/test/{regime}/customer-files':
     $ref: 'paths/admin/test/customers.yml'
 
-  '/admin/test/customers/{customerFileId}':
+  '/admin/test/customer-files/{customerFileId}':
     $ref: 'paths/admin/test/customer.yml'
 
   '/admin/test/data-export':

--- a/openapi/versions/draft.yml
+++ b/openapi/versions/draft.yml
@@ -986,7 +986,7 @@ paths:
                   count: 10
                 - type: minimum-charge
                   count: 10
-  "/admin/test/{regime}/customers":
+  "/admin/test/{regime}/customer-files":
     get:
       operationId: ListCustomerFiles
       description: Request a list of 'customer files'. Each record contains the details
@@ -1091,7 +1091,7 @@ paths:
                 updatedAt: '2021-04-29T13:15:30.690Z'
                 status: exported
                 exportedAt: '2021-04-29T13:15:30.683Z'
-  "/admin/test/customers/{customerFileId}":
+  "/admin/test/customer-files/{customerFileId}":
     get:
       operationId: ViewCustomerFile
       description: Request details of a 'customer file'. Returns the 'customer file'


### PR DESCRIPTION
We've just spotted that the test customer-file endpoints in the spec (`/admin/test/{regime}/customers` and `/admin/test/customers/{customerFileId}`) do not match what is actually in the API (`/admin/test/{regime}/customer-files` and `/admin/test/customer-files/{customerFileId}`). This change fixes it.