### PR TITLE
Fix Customer Files endpoint ID's

### DIFF
--- a/openapi/paths/admin/test/customers.yml
+++ b/openapi/paths/admin/test/customers.yml
@@ -1,5 +1,5 @@
 get:
-  operationId: ListCustomerFiles
+  operationId: ListCustomerFilesTest
   description: "Request a list of 'customer files'. Each record contains the details for a file of customer changes the API generated and sent to SSCL."
   tags:
     - admin

--- a/openapi/versions/draft.yml
+++ b/openapi/versions/draft.yml
@@ -108,32 +108,30 @@ info:
     name: Open Government Licence (OGL)
     url: http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3
 servers:
-- description: Local
-  url: http://localhost:3003
+  - description: Local
+    url: http://localhost:3003
 tags:
-- name: bill-run
-  description: Operations related to bill runs
-- name: calculate
-  description: Operations related to calculating charges
-- name: customer
-  description: Operations related to customer files
-- name: unavailable
-  description: These will become available eventually but are yet to be fully implemented
-- name: admin
-  description: Used to administer, monitor, and test the service. Only available when
-    authenticating as an 'admin'
-- name: status
-  description: Endpoints that can be used to confirm the status of the API or by automated
-    'health checks'
+  - name: bill-run
+    description: Operations related to bill runs
+  - name: calculate
+    description: Operations related to calculating charges
+  - name: customer
+    description: Operations related to customer files
+  - name: unavailable
+    description: These will become available eventually but are yet to be fully implemented
+  - name: admin
+    description: Used to administer, monitor, and test the service. Only available when authenticating as an 'admin'
+  - name: status
+    description: Endpoints that can be used to confirm the status of the API or by automated 'health checks'
 paths:
-  "/":
+  /:
     get:
       operationId: Root
       description: Confirm service is up and running. Exactly the same as `/status`
       tags:
-      - status
+        - status
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -143,29 +141,28 @@ paths:
                   status:
                     type: string
                     example: alive
-  "/status":
+  /status:
     get:
       operationId: Status
       description: Confirm service is up and running
       tags:
-      - status
+        - status
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
               schema:
                 example:
                   status: alive
-  "/admin/regimes":
+  /admin/regimes:
     get:
       operationId: ListRegimes
-      description: Request a list of the charging regimes recognised and managed by
-        the service
+      description: Request a list of the charging regimes recognised and managed by the service
       tags:
-      - admin
+        - admin
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -175,85 +172,81 @@ paths:
                   type: object
                   properties:
                     id:
-                      description: Internal ID (GUID) allocated by the CM when creating
-                        a regime.
+                      description: Internal ID (GUID) allocated by the CM when creating a regime.
                       type: string
                       format: uuid
                       example: fd2ab097-3097-42bd-849e-046aa250a0d0
                     slug:
-                      description: Short reference for a regime, referred to as a
-                        'slug'. This is also what we expect to see in the path as
-                        the regime identifier when making a request
+                      description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
                       type: string
                       enum:
-                      - cfd
-                      - pas
-                      - wml
-                      - wrls
+                        - cfd
+                        - pas
+                        - wml
+                        - wrls
                       example: wrls
                     name:
-                      description: The name assigned by the service team to the client
-                        system
+                      description: The name assigned by the service team to the client system
                       type: string
                       example: Water Resources
                     preSrocCutoffDate:
                       description: Date when rules changed from pre-SROC to SROC based
                       type: string
                       format: date
-                      example: '2020-04-01'
+                      example: "2020-04-01"
                     createdAt:
                       description: Date and time the record was created
                       type: string
                       format: datetime
-                      example: '2020-09-11T11:56:41.578Z'
+                      example: "2020-09-11T11:56:41.578Z"
                     updatedAt:
                       description: Date and time the record was last updated
                       type: string
                       format: datetime
-                      example: '2020-09-11T11:56:41.578Z'
+                      example: "2020-09-11T11:56:41.578Z"
               example:
-              - id: ef5ee223-2ee5-4f02-ace5-35330d9f3781
-                slug: cfd
-                name: Water Quality
-                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
-                createdAt: '2020-12-01T09:19:22.065Z'
-                updatedAt: '2020-12-01T09:19:22.065Z'
-              - id: 6bd74eeb-6beb-41d9-be52-5934a49ecd97
-                slug: pas
-                name: Installations
-                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
-                createdAt: '2020-12-01T09:19:22.065Z'
-                updatedAt: '2020-12-01T09:19:22.065Z'
-              - id: 458834a2-0541-4981-87f6-2c0ec9261661
-                slug: wml
-                name: Waste
-                preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
-                createdAt: '2020-12-01T09:19:22.065Z'
-                updatedAt: '2020-12-01T09:19:22.065Z'
-              - id: 2f62bc92-7372-4d2a-979b-792e530c311c
-                slug: wrls
-                name: Water Resources
-                preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
-                createdAt: '2020-12-01T09:19:22.065Z'
-                updatedAt: '2020-12-01T09:19:22.065Z'
-  "/admin/regimes/{regimeId}":
+                - id: ef5ee223-2ee5-4f02-ace5-35330d9f3781
+                  slug: cfd
+                  name: Water Quality
+                  preSrocCutoffDate: "2018-04-01T00:00:00.000Z"
+                  createdAt: "2020-12-01T09:19:22.065Z"
+                  updatedAt: "2020-12-01T09:19:22.065Z"
+                - id: 6bd74eeb-6beb-41d9-be52-5934a49ecd97
+                  slug: pas
+                  name: Installations
+                  preSrocCutoffDate: "2018-04-01T00:00:00.000Z"
+                  createdAt: "2020-12-01T09:19:22.065Z"
+                  updatedAt: "2020-12-01T09:19:22.065Z"
+                - id: 458834a2-0541-4981-87f6-2c0ec9261661
+                  slug: wml
+                  name: Waste
+                  preSrocCutoffDate: "2018-04-01T00:00:00.000Z"
+                  createdAt: "2020-12-01T09:19:22.065Z"
+                  updatedAt: "2020-12-01T09:19:22.065Z"
+                - id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                  slug: wrls
+                  name: Water Resources
+                  preSrocCutoffDate: "2020-04-01T00:00:00.000Z"
+                  createdAt: "2020-12-01T09:19:22.065Z"
+                  updatedAt: "2020-12-01T09:19:22.065Z"
+  /admin/regimes/{regimeId}:
     get:
       operationId: ViewRegime
       description: Request details of a 'regime'.
       tags:
-      - admin
+        - admin
       parameters:
-      - name: regimeId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a regime.
-        schema:
+        - name: regimeId
+          in: path
+          required: true
           description: Internal ID (GUID) allocated by the CM when creating a regime.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a regime.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -261,105 +254,93 @@ paths:
                 type: object
                 properties:
                   id:
-                    description: Internal ID (GUID) allocated by the CM when creating
-                      a regime.
+                    description: Internal ID (GUID) allocated by the CM when creating a regime.
                     type: string
                     format: uuid
                     example: fd2ab097-3097-42bd-849e-046aa250a0d0
                   slug:
-                    description: Short reference for a regime, referred to as a 'slug'.
-                      This is also what we expect to see in the path as the regime
-                      identifier when making a request
+                    description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
                     type: string
                     enum:
-                    - cfd
-                    - pas
-                    - wml
-                    - wrls
+                      - cfd
+                      - pas
+                      - wml
+                      - wrls
                     example: wrls
                   name:
-                    description: The name assigned by the service team to the client
-                      system
+                    description: The name assigned by the service team to the client system
                     type: string
                     example: Water Resources
                   preSrocCutoffDate:
                     description: Date when rules changed from pre-SROC to SROC based
                     type: string
                     format: date
-                    example: '2020-04-01'
+                    example: "2020-04-01"
                   createdAt:
                     description: Date and time the record was created
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
                   updatedAt:
                     description: Date and time the record was last updated
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
                   authorisedSystems:
                     type: array
                     items:
                       type: object
                       properties:
                         id:
-                          description: Internal ID (GUID) allocated by the CM when
-                            creating an authorised system.
+                          description: Internal ID (GUID) allocated by the CM when creating an authorised system.
                           type: string
                           format: uuid
                           example: fd2ab097-3097-42bd-849e-046aa250a0d0
                         clientId:
-                          description: Known as a 'client ID' this is generated by
-                            AWS Cognito and used to identify which client is requesting
-                            access to the API.
+                          description: Known as a 'client ID' this is generated by AWS Cognito and used to identify which client is requesting access to the API.
                           type: string
                           example: i7rnixijjrawj7azzhwwxxxxxx
                         name:
-                          description: The name assigned by the service team to the
-                            client system
+                          description: The name assigned by the service team to the client system
                           type: string
                           example: Water Resources
                         status:
-                          description: Only 'active' authorised system accounts can
-                            interact with the API. Because records will be linked
-                            to an authorised system, when they become redundant we
-                            mark them as 'inactive' rather than delete them
+                          description: Only 'active' authorised system accounts can interact with the API. Because records will be linked to an authorised system, when they become redundant we mark them as 'inactive' rather than delete them
                           type: string
                           enum:
-                          - active
-                          - inactive
+                            - active
+                            - inactive
                           example: active
                         admin:
-                          description: Boolean indicator to show whether or not the
-                            authorised system is an 'admin' user of the API
+                          description: Boolean indicator to show whether or not the authorised system is an 'admin' user of the API
                           type: boolean
                           example: false
                         createdAt:
                           description: Date and time the record was created
                           type: string
                           format: datetime
-                          example: '2020-09-11T11:56:41.578Z'
+                          example: "2020-09-11T11:56:41.578Z"
                         updatedAt:
                           description: Date and time the record was last updated
                           type: string
                           format: datetime
-                          example: '2020-09-11T11:56:41.578Z'
+                          example: "2020-09-11T11:56:41.578Z"
               example:
                 id: 2f62bc92-7372-4d2a-979b-792e530c311c
                 slug: wrls
                 name: Water Resources
-                preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
-                createdAt: '2020-12-01T09:19:22.065Z'
-                updatedAt: '2020-12-01T09:19:22.065Z'
+                preSrocCutoffDate: "2020-04-01T00:00:00.000Z"
+                createdAt: "2020-12-01T09:19:22.065Z"
+                updatedAt: "2020-12-01T09:19:22.065Z"
                 authorisedSystems:
-                - id: b36d674f-b97c-4685-95f3-aacae8c97bde
-                  clientId: 1b1gshltt176v80nsc4fxxxxxx
-                  name: wrls
-                  status: active
-                  admin: 'false'
-                  createdAt: '2020-12-02T09:19:22.065Z'
-                  updatedAt: '2020-12-02T09:19:22.065Z'
-        '404':
+                  - id: b36d674f-b97c-4685-95f3-aacae8c97bde
+                    clientId: 1b1gshltt176v80nsc4fxxxxxx
+                    name: wrls
+                    status: active
+                    admin: "false"
+                    createdAt: "2020-12-02T09:19:22.065Z"
+                    updatedAt: "2020-12-02T09:19:22.065Z"
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -368,16 +349,14 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: No regime found with id 83562322-cb05-48cc-bc43-b06b3e5381f6
-  "/admin/authorised-systems":
+  /admin/authorised-systems:
     get:
       operationId: ListAuthorisedSystems
-      description: Request a list of 'authorised systems'. An authorised system is
-        essentially a user of the API, and this returns those users permitted to access
-        it.
+      description: Request a list of 'authorised systems'. An authorised system is essentially a user of the API, and this returns those users permitted to access it.
       tags:
-      - admin
+        - admin
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -390,70 +369,61 @@ paths:
                       type: object
                       properties:
                         id:
-                          description: Internal ID (GUID) allocated by the CM when
-                            creating an authorised system.
+                          description: Internal ID (GUID) allocated by the CM when creating an authorised system.
                           type: string
                           format: uuid
                           example: fd2ab097-3097-42bd-849e-046aa250a0d0
                         clientId:
-                          description: Known as a 'client ID' this is generated by
-                            AWS Cognito and used to identify which client is requesting
-                            access to the API.
+                          description: Known as a 'client ID' this is generated by AWS Cognito and used to identify which client is requesting access to the API.
                           type: string
                           example: i7rnixijjrawj7azzhwwxxxxxx
                         name:
-                          description: The name assigned by the service team to the
-                            client system
+                          description: The name assigned by the service team to the client system
                           type: string
                           example: Water Resources
                         status:
-                          description: Only 'active' authorised system accounts can
-                            interact with the API. Because records will be linked
-                            to an authorised system, when they become redundant we
-                            mark them as 'inactive' rather than delete them
+                          description: Only 'active' authorised system accounts can interact with the API. Because records will be linked to an authorised system, when they become redundant we mark them as 'inactive' rather than delete them
                           type: string
                           enum:
-                          - active
-                          - inactive
+                            - active
+                            - inactive
                           example: active
                         admin:
-                          description: Boolean indicator to show whether or not the
-                            authorised system is an 'admin' user of the API
+                          description: Boolean indicator to show whether or not the authorised system is an 'admin' user of the API
                           type: boolean
                           example: false
                         createdAt:
                           description: Date and time the record was created
                           type: string
                           format: datetime
-                          example: '2020-09-11T11:56:41.578Z'
+                          example: "2020-09-11T11:56:41.578Z"
                         updatedAt:
                           description: Date and time the record was last updated
                           type: string
                           format: datetime
-                          example: '2020-09-11T11:56:41.578Z'
+                          example: "2020-09-11T11:56:41.578Z"
               example:
-              - id: ac12ac4b-9b9e-4cba-a06f-a90f611a1ef1
-                clientId: 710uhe3hqumsk2da43foxxxxxx
-                name: admin
-                status: active
-                admin: 'true'
-                createdAt: '2020-11-01T09:19:22.065Z'
-                updatedAt: '2020-11-01T09:19:22.065Z'
-              - id: b36d674f-b97c-4685-95f3-aacae8c97bde
-                clientId: 1b1gshltt176v80nsc4fxxxxxx
-                name: wrls
-                status: active
-                admin: 'false'
-                createdAt: '2020-12-02T09:19:22.065Z'
-                updatedAt: '2020-12-02T09:19:22.065Z'
+                - id: ac12ac4b-9b9e-4cba-a06f-a90f611a1ef1
+                  clientId: 710uhe3hqumsk2da43foxxxxxx
+                  name: admin
+                  status: active
+                  admin: "true"
+                  createdAt: "2020-11-01T09:19:22.065Z"
+                  updatedAt: "2020-11-01T09:19:22.065Z"
+                - id: b36d674f-b97c-4685-95f3-aacae8c97bde
+                  clientId: 1b1gshltt176v80nsc4fxxxxxx
+                  name: wrls
+                  status: active
+                  admin: "false"
+                  createdAt: "2020-12-02T09:19:22.065Z"
+                  updatedAt: "2020-12-02T09:19:22.065Z"
     post:
       operationId: AddAuthorisedSystem
-      description: Add a new 'authorised system'. An authorised system is essentially
-        a user of the API, and this adds a new one to it.
+      description: Add a new 'authorised system'. An authorised system is essentially a user of the API, and this adds a new one to it.
       tags:
-      - admin
+        - admin
       responses:
-        '201':
+        "201":
           description: Success
           content:
             application/json:
@@ -461,80 +431,72 @@ paths:
                 type: object
                 properties:
                   id:
-                    description: Internal ID (GUID) allocated by the CM when creating
-                      an authorised system.
+                    description: Internal ID (GUID) allocated by the CM when creating an authorised system.
                     type: string
                     format: uuid
                     example: fd2ab097-3097-42bd-849e-046aa250a0d0
                   clientId:
-                    description: Known as a 'client ID' this is generated by AWS Cognito
-                      and used to identify which client is requesting access to the
-                      API.
+                    description: Known as a 'client ID' this is generated by AWS Cognito and used to identify which client is requesting access to the API.
                     type: string
                     example: i7rnixijjrawj7azzhwwxxxxxx
                   name:
-                    description: The name assigned by the service team to the client
-                      system
+                    description: The name assigned by the service team to the client system
                     type: string
                     example: Water Resources
                   status:
-                    description: Only 'active' authorised system accounts can interact
-                      with the API. Because records will be linked to an authorised
-                      system, when they become redundant we mark them as 'inactive'
-                      rather than delete them
+                    description: Only 'active' authorised system accounts can interact with the API. Because records will be linked to an authorised system, when they become redundant we mark them as 'inactive' rather than delete them
                     type: string
                     enum:
-                    - active
-                    - inactive
+                      - active
+                      - inactive
                     example: active
                   admin:
-                    description: Boolean indicator to show whether or not the authorised
-                      system is an 'admin' user of the API
+                    description: Boolean indicator to show whether or not the authorised system is an 'admin' user of the API
                     type: boolean
                     example: false
                   createdAt:
                     description: Date and time the record was created
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
                   updatedAt:
                     description: Date and time the record was last updated
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
               example:
                 id: 9e76203a-e900-41a1-a045-2551d98e010c
                 clientId: i7rnixijjrawj7azzhwwxxxxxx
                 name: dashboard
                 status: active
-                admin: 'false'
-                createdAt: '2020-12-04T09:19:22.065Z'
-                updatedAt: '2020-12-04T09:19:22.065Z'
+                admin: "false"
+                createdAt: "2020-12-04T09:19:22.065Z"
+                updatedAt: "2020-12-04T09:19:22.065Z"
                 regimes:
-                - id: ef5ee223-2ee5-4f02-ace5-35330d9f3781
-                  slug: cfd
-                  name: Water Quality
-                  preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
-                  createdAt: '2020-12-01T09:19:22.065Z'
-                  updatedAt: '2020-12-01T09:19:22.065Z'
-                - id: 6bd74eeb-6beb-41d9-be52-5934a49ecd97
-                  slug: pas
-                  name: Installations
-                  preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
-                  createdAt: '2020-12-01T09:19:22.065Z'
-                  updatedAt: '2020-12-01T09:19:22.065Z'
-                - id: 458834a2-0541-4981-87f6-2c0ec9261661
-                  slug: wml
-                  name: Waste
-                  preSrocCutoffDate: '2018-04-01T00:00:00.000Z'
-                  createdAt: '2020-12-01T09:19:22.065Z'
-                  updatedAt: '2020-12-01T09:19:22.065Z'
-                - id: 2f62bc92-7372-4d2a-979b-792e530c311c
-                  slug: wrls
-                  name: Water Resources
-                  preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
-                  createdAt: '2020-12-01T09:19:22.065Z'
-                  updatedAt: '2020-12-01T09:19:22.065Z'
+                  - id: ef5ee223-2ee5-4f02-ace5-35330d9f3781
+                    slug: cfd
+                    name: Water Quality
+                    preSrocCutoffDate: "2018-04-01T00:00:00.000Z"
+                    createdAt: "2020-12-01T09:19:22.065Z"
+                    updatedAt: "2020-12-01T09:19:22.065Z"
+                  - id: 6bd74eeb-6beb-41d9-be52-5934a49ecd97
+                    slug: pas
+                    name: Installations
+                    preSrocCutoffDate: "2018-04-01T00:00:00.000Z"
+                    createdAt: "2020-12-01T09:19:22.065Z"
+                    updatedAt: "2020-12-01T09:19:22.065Z"
+                  - id: 458834a2-0541-4981-87f6-2c0ec9261661
+                    slug: wml
+                    name: Waste
+                    preSrocCutoffDate: "2018-04-01T00:00:00.000Z"
+                    createdAt: "2020-12-01T09:19:22.065Z"
+                    updatedAt: "2020-12-01T09:19:22.065Z"
+                  - id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                    slug: wrls
+                    name: Water Resources
+                    preSrocCutoffDate: "2020-04-01T00:00:00.000Z"
+                    createdAt: "2020-12-01T09:19:22.065Z"
+                    updatedAt: "2020-12-01T09:19:22.065Z"
       requestBody:
         content:
           application/json:
@@ -542,70 +504,58 @@ paths:
               type: object
               properties:
                 clientId:
-                  description: Known as a 'client ID' this is generated by AWS Cognito
-                    and used to identify which client is requesting access to the
-                    API.
+                  description: Known as a 'client ID' this is generated by AWS Cognito and used to identify which client is requesting access to the API.
                   type: string
                   example: i7rnixijjrawj7azzhwwxxxxxx
                 name:
-                  description: The name assigned by the service team to the client
-                    system
+                  description: The name assigned by the service team to the client system
                   type: string
                   example: Water Resources
                 status:
-                  description: Only 'active' authorised system accounts can interact
-                    with the API. Because records will be linked to an authorised
-                    system, when they become redundant we mark them as 'inactive'
-                    rather than delete them
+                  description: Only 'active' authorised system accounts can interact with the API. Because records will be linked to an authorised system, when they become redundant we mark them as 'inactive' rather than delete them
                   type: string
                   enum:
-                  - active
-                  - inactive
+                    - active
+                    - inactive
                   example: active
                 authorisations:
                   type: array
                   items:
-                    description: Short reference for a regime, referred to as a 'slug'.
-                      This is also what we expect to see in the path as the regime
-                      identifier when making a request
+                    description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
                     type: string
                     enum:
-                    - cfd
-                    - pas
-                    - wml
-                    - wrls
+                      - cfd
+                      - pas
+                      - wml
+                      - wrls
                     example: wrls
             example:
               clientId: i7rnixijjrawj7azzhwwxxxxxx
               name: dashboard
               status: active
               authorisations:
-              - cfd
-              - pas
-              - wml
-              - wrls
-  "/admin/authorised-systems/{authorisedSystemId}":
+                - cfd
+                - pas
+                - wml
+                - wrls
+  /admin/authorised-systems/{authorisedSystemId}:
     get:
       operationId: ViewAuthorisedSystem
-      description: Request details of an 'authorised system'. An authorised system
-        is essentially a user of the API, and this returns details about it including
-        which regimes it is authorised to access.
+      description: Request details of an 'authorised system'. An authorised system is essentially a user of the API, and this returns details about it including which regimes it is authorised to access.
       tags:
-      - admin
+        - admin
       parameters:
-      - name: authorisedSystemId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating an authorised
-          system.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating an authorised
-            system.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: authorisedSystemId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating an authorised system.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating an authorised system.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -613,130 +563,111 @@ paths:
                 type: object
                 properties:
                   id:
-                    description: Internal ID (GUID) allocated by the CM when creating
-                      an authorised system.
+                    description: Internal ID (GUID) allocated by the CM when creating an authorised system.
                     type: string
                     format: uuid
                     example: fd2ab097-3097-42bd-849e-046aa250a0d0
                   clientId:
-                    description: Known as a 'client ID' this is generated by AWS Cognito
-                      and used to identify which client is requesting access to the
-                      API.
+                    description: Known as a 'client ID' this is generated by AWS Cognito and used to identify which client is requesting access to the API.
                     type: string
                     example: i7rnixijjrawj7azzhwwxxxxxx
                   name:
-                    description: The name assigned by the service team to the client
-                      system
+                    description: The name assigned by the service team to the client system
                     type: string
                     example: Water Resources
                   status:
-                    description: Only 'active' authorised system accounts can interact
-                      with the API. Because records will be linked to an authorised
-                      system, when they become redundant we mark them as 'inactive'
-                      rather than delete them
+                    description: Only 'active' authorised system accounts can interact with the API. Because records will be linked to an authorised system, when they become redundant we mark them as 'inactive' rather than delete them
                     type: string
                     enum:
-                    - active
-                    - inactive
+                      - active
+                      - inactive
                     example: active
                   admin:
-                    description: Boolean indicator to show whether or not the authorised
-                      system is an 'admin' user of the API
+                    description: Boolean indicator to show whether or not the authorised system is an 'admin' user of the API
                     type: boolean
                     example: false
                   createdAt:
                     description: Date and time the record was created
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
                   updatedAt:
                     description: Date and time the record was last updated
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
                   regimes:
                     type: array
                     items:
                       type: object
                       properties:
                         id:
-                          description: Internal ID (GUID) allocated by the CM when
-                            creating a regime.
+                          description: Internal ID (GUID) allocated by the CM when creating a regime.
                           type: string
                           format: uuid
                           example: fd2ab097-3097-42bd-849e-046aa250a0d0
                         slug:
-                          description: Short reference for a regime, referred to as
-                            a 'slug'. This is also what we expect to see in the path
-                            as the regime identifier when making a request
+                          description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
                           type: string
                           enum:
-                          - cfd
-                          - pas
-                          - wml
-                          - wrls
+                            - cfd
+                            - pas
+                            - wml
+                            - wrls
                           example: wrls
                         name:
-                          description: The name assigned by the service team to the
-                            client system
+                          description: The name assigned by the service team to the client system
                           type: string
                           example: Water Resources
                         preSrocCutoffDate:
-                          description: Date when rules changed from pre-SROC to SROC
-                            based
+                          description: Date when rules changed from pre-SROC to SROC based
                           type: string
                           format: date
-                          example: '2020-04-01'
+                          example: "2020-04-01"
                         createdAt:
                           description: Date and time the record was created
                           type: string
                           format: datetime
-                          example: '2020-09-11T11:56:41.578Z'
+                          example: "2020-09-11T11:56:41.578Z"
                         updatedAt:
                           description: Date and time the record was last updated
                           type: string
                           format: datetime
-                          example: '2020-09-11T11:56:41.578Z'
+                          example: "2020-09-11T11:56:41.578Z"
               example:
                 id: b36d674f-b97c-4685-95f3-aacae8c97bde
                 clientId: 1b1gshltt176v80nsc4fxxxxxx
                 name: wrls
                 status: active
-                admin: 'false'
-                createdAt: '2020-12-02T09:19:22.065Z'
-                updatedAt: '2020-12-02T09:19:22.065Z'
+                admin: "false"
+                createdAt: "2020-12-02T09:19:22.065Z"
+                updatedAt: "2020-12-02T09:19:22.065Z"
                 regimes:
-                - id: 2f62bc92-7372-4d2a-979b-792e530c311c
-                  slug: wrls
-                  name: Water Resources
-                  preSrocCutoffDate: '2020-04-01T00:00:00.000Z'
-                  createdAt: '2020-12-01T09:19:22.065Z'
-                  updatedAt: '2020-12-01T09:19:22.065Z'
+                  - id: 2f62bc92-7372-4d2a-979b-792e530c311c
+                    slug: wrls
+                    name: Water Resources
+                    preSrocCutoffDate: "2020-04-01T00:00:00.000Z"
+                    createdAt: "2020-12-01T09:19:22.065Z"
+                    updatedAt: "2020-12-01T09:19:22.065Z"
     patch:
       operationId: UpdateAuthorisedSystem
-      description: Update an 'authorised system'. An authorised system is essentially
-        a user of the API, and this is used to update the details of one. You don't
-        have to specify all properties when updating. If you specify `authorisations`
-        though, you must include all regimes you want the system to have access to,
-        not just the ones you wish to add.
+      description: Update an 'authorised system'. An authorised system is essentially a user of the API, and this is used to update the details of one. You don't have to specify all properties when updating. If you specify `authorisations` though, you must include all regimes you want the system to have access to, not just the ones you wish to add.
       tags:
-      - admin
+        - admin
       parameters:
-      - name: authorisedSystemId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating an authorised
-          system.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating an authorised
-            system.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: authorisedSystemId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating an authorised system.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating an authorised system.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '204':
+        "204":
           description: Success
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -752,80 +683,68 @@ paths:
               type: object
               properties:
                 name:
-                  description: The name assigned by the service team to the client
-                    system
+                  description: The name assigned by the service team to the client system
                   type: string
                   example: Water Resources
                 status:
-                  description: Only 'active' authorised system accounts can interact
-                    with the API. Because records will be linked to an authorised
-                    system, when they become redundant we mark them as 'inactive'
-                    rather than delete them
+                  description: Only 'active' authorised system accounts can interact with the API. Because records will be linked to an authorised system, when they become redundant we mark them as 'inactive' rather than delete them
                   type: string
                   enum:
-                  - active
-                  - inactive
+                    - active
+                    - inactive
                   example: active
                 authorisations:
                   type: array
                   items:
-                    description: Short reference for a regime, referred to as a 'slug'.
-                      This is also what we expect to see in the path as the regime
-                      identifier when making a request
+                    description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
                     type: string
                     enum:
-                    - cfd
-                    - pas
-                    - wml
-                    - wrls
+                      - cfd
+                      - pas
+                      - wml
+                      - wrls
                     example: wrls
             example:
               name: Test
               status: inactive
               authorisations:
+                - cfd
+                - pas
+                - wml
+                - wrls
+  /admin/{regime}/bill-runs/{billRunId}/send:
+    patch:
+      operationId: AdminSendBillRun
+      description: Triggers creation of a transaction file containing all transactions in the bill run. Bill run must be `pending` else the request will be rejected. This endpoint will wait until the file has been created before returning a response.
+      tags:
+        - admin
+      parameters:
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
               - cfd
               - pas
               - wml
               - wrls
-  "/admin/{regime}/bill-runs/{billRunId}/send":
-    patch:
-      operationId: AdminSendBillRun
-      description: Triggers creation of a transaction file containing all transactions
-        in the bill run. Bill run must be `pending` else the request will be rejected.
-        This endpoint will wait until the file has been created before returning a
-        response.
-      tags:
-      - admin
-      parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '204':
+        "204":
           description: Success
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -834,7 +753,7 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
-        '409':
+        "409":
           description: Failed - the bill run is not in the right state
           content:
             application/json:
@@ -842,9 +761,8 @@ paths:
                 example:
                   statusCode: 409
                   error: Conflict
-                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not
-                    have a status of 'pending'.
-        '422':
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not have a status of 'pending'.
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -852,99 +770,72 @@ paths:
                 example:
                   statusCode: 422
                   error: Unprocessable Entity
-                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked
-                    to regime wrls.
-  "/admin/{regime}/customers":
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
+  /admin/{regime}/customers:
     patch:
       operationId: SendCustomer
-      description: Manually trigger the send customer files process. This triggers
-        creation of a file of customer changes for each regime.
+      description: Manually trigger the send customer files process. This triggers creation of a file of customer changes for each regime.
       tags:
-      - admin
+        - admin
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
       responses:
-        '204':
+        "204":
           description: Success
-  "/admin/health/airbrake":
+  /admin/health/airbrake:
     get:
       operationId: CheckAirbrake
       description: Used to confirm Airbrake is connected correctly to an environment
       tags:
-      - admin
+        - admin
       responses:
-        '500':
-          description: An error has been thrown on purpose by the API. Check either
-            the production or non-production instance of Errbit to confirm it received
-            the error
-  "/admin/health/database":
+        "500":
+          description: An error has been thrown on purpose by the API. Check either the production or non-production instance of Errbit to confirm it received the error
+  /admin/health/database:
     get:
       operationId: CheckDatabase
       description: |-
         Used to check the API is correctly connected to the database in an environment. Will also provide some general stats about the data held
         > The endpoint does return a JSON response. However, it's pretty sizable and just a JSON version of [pg_stat_user_tables](http://www.postgresql.cn/docs/10/monitoring-stats.html#PG-STAT-ALL-TABLES-VIEW). So we don't document it here.
       tags:
-      - admin
+        - admin
       responses:
-        '200':
+        "200":
           description: Success
-  "/admin/test/{regime}/bill-runs":
+  /admin/test/{regime}/bill-runs:
     post:
       operationId: CreateTestBillRun
-      description: "This endpoint creates a test bill run for a region. It is intended
-        for quickly creating large bill runs so we can access the performance and
-        operation of endpoints when working with them. You can control the type of
-        invoices generated within the bill run using the request payload. The types
-        are\n- `mixed-invoice` - 2 debit lines and 1 credit line resulting in an invoice\n-
-        `mixed-credit` - 2 credit lines and 1 debit line resulting in a credit note\n-
-        `zero-value` - 3 debit transactions all with a charge value of 0\n- `deminimis`
-        - 3 debit transactions that total less than £5\n- `minimum-charge` - 3 debit
-        transactions that total less than £25 and are all subject to minimum charge\n\nEvery
-        invoice created results in 3 transactions. So, the following request would
-        result in a bill run with 100 invoices and 300 transactions.\n\n``` { \"region\":
-        \"A\", \"mix\": [ { \"type\": \"mixed-invoice\", \"count\": 40 }, { \"type\":
-        \"mixed-credit\", \"count\": 40 }, { \"type\": \"zero-value\", \"count\":
-        10 }, { \"type\": \"deminimis\", \"count\": 10 } ] } ```\n\nThe endpoint has
-        been designed to generate the bill run as quickly as possible. To do this
-        we **do not** call the rules service. The values used are based on real calculations,
-        but should the rules service calculation change it won't be reflected here.\n\nThe
-        endpoint returns the new bill run ID immediately, but may take sometime to
-        create all the invoices. If you have access to it, check the log for a message
-        that will confirm when the process is complete. "
+      description: "This endpoint creates a test bill run for a region. It is intended for quickly creating large bill runs so we can access the performance and operation of endpoints when working with them. You can control the type of invoices generated within the bill run using the request payload. The types are\n- `mixed-invoice` - 2 debit lines and 1 credit line resulting in an invoice\n- `mixed-credit` - 2 credit lines and 1 debit line resulting in a credit note\n- `zero-value` - 3 debit transactions all with a charge value of 0\n- `deminimis` - 3 debit transactions that total less than £5\n- `minimum-charge` - 3 debit transactions that total less than £25 and are all subject to minimum charge\n\nEvery invoice created results in 3 transactions. So, the following request would result in a bill run with 100 invoices and 300 transactions.\n\n``` { \"region\": \"A\", \"mix\": [ { \"type\": \"mixed-invoice\", \"count\": 40 }, { \"type\": \"mixed-credit\", \"count\": 40 }, { \"type\": \"zero-value\", \"count\": 10 }, { \"type\": \"deminimis\", \"count\": 10 } ] } ```\n\nThe endpoint has been designed to generate the bill run as quickly as possible. To do this we **do not** call the rules service. The values used are based on real calculations, but should the rules service calculation change it won't be reflected here.\n\nThe endpoint returns the new bill run ID immediately, but may take sometime to create all the invoices. If you have access to it, check the log for a message that will confirm when the process is complete. "
       tags:
-      - admin
+        - admin
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
       responses:
-        '201':
+        "201":
           description: Success
           content:
             application/json:
@@ -953,9 +844,8 @@ paths:
                   billRun:
                     id: 2bbbe459-966e-4026-b5d2-2f10867bdddd
                     billRunNumber: 10004
-        '422':
-          description: Failed - bill run cannot be generated because there is an issue
-            with its data
+        "422":
+          description: Failed - bill run cannot be generated because there is an issue with its data
           content:
             application/json:
               examples:
@@ -976,41 +866,38 @@ paths:
               example:
                 region: A
                 mix:
-                - type: mixed-invoice
-                  count: 35
-                - type: mixed-credit
-                  count: 35
-                - type: zero-value
-                  count: 10
-                - type: deminimis
-                  count: 10
-                - type: minimum-charge
-                  count: 10
-  "/admin/test/{regime}/customer-files":
+                  - type: mixed-invoice
+                    count: 35
+                  - type: mixed-credit
+                    count: 35
+                  - type: zero-value
+                    count: 10
+                  - type: deminimis
+                    count: 10
+                  - type: minimum-charge
+                    count: 10
+  /admin/test/{regime}/customer-files:
     get:
-      operationId: ListCustomerFiles
-      description: Request a list of 'customer files'. Each record contains the details
-        for a file of customer changes the API generated and sent to SSCL.
+      operationId: ListCustomerFilesTest
+      description: Request a list of 'customer files'. Each record contains the details for a file of customer changes the API generated and sent to SSCL.
       tags:
-      - admin
+        - admin
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -1018,101 +905,90 @@ paths:
                 type: object
                 properties:
                   id:
-                    description: Internal ID (GUID) allocated by the CM when creating
-                      a customer file
+                    description: Internal ID (GUID) allocated by the CM when creating a customer file
                     type: string
                     format: uuid
                     example: fd2ab097-3097-42bd-849e-046aa250a0d0
                   regimeId:
-                    description: Internal ID (GUID) allocated by the CM when creating
-                      a regime.
+                    description: Internal ID (GUID) allocated by the CM when creating a regime.
                     type: string
                     format: uuid
                     example: fd2ab097-3097-42bd-849e-046aa250a0d0
                   region:
-                    description: A single-digit region identifier for a transaction
-                      or customer
+                    description: A single-digit region identifier for a transaction or customer
                     type: string
                     enum:
-                    - A
-                    - B
-                    - E
-                    - N
-                    - S
-                    - T
-                    - W
-                    - Y
+                      - A
+                      - B
+                      - E
+                      - "N"
+                      - S
+                      - T
+                      - W
+                      - "Y"
                     example: A
                   fileReference:
-                    description: A 10-digit reference indicating the name of the customer
-                      file generated by the CM for notifying SSCL of new / updated
-                      customer records
+                    description: A 10-digit reference indicating the name of the customer file generated by the CM for notifying SSCL of new / updated customer records
                     type: string
                     example: nalsc50004
                   createdAt:
                     description: Date and time the record was created
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
                   updatedAt:
                     description: Date and time the record was last updated
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
                   status:
-                    description: Current status of the customer file. Note - if a
-                      file has a status of `pending` for more than a few minutes it
-                      is likely an issue as occurred during the generation
+                    description: Current status of the customer file. Note - if a file has a status of `pending` for more than a few minutes it is likely an issue as occurred during the generation
                     type: string
                     enum:
-                    - initialised
-                    - pending
-                    - exported
+                      - initialised
+                      - pending
+                      - exported
                     example: exported
                   exportedAt:
                     description: Date and time at which the customer file was generated
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
               example:
-              - id: d04652ab-8ddb-411e-b683-53c25855f7a3
-                regimeId: 34eb63e4-c538-48ca-9053-86164d12248c
-                region: T
-                fileReference: naltc50002
-                createdAt: '2021-04-29T13:15:30.012Z'
-                updatedAt: '2021-04-29T13:15:30.374Z'
-                status: exported
-                exportedAt: '2021-04-29T13:15:30.366Z'
-              - id: aed6eb7c-6876-4c32-a8a5-5bc84cf2b0f4
-                regimeId: 34eb63e4-c538-48ca-9053-86164d12248c
-                region: Y
-                fileReference: nalyc50002
-                createdAt: '2021-04-29T13:15:30.413Z'
-                updatedAt: '2021-04-29T13:15:30.690Z'
-                status: exported
-                exportedAt: '2021-04-29T13:15:30.683Z'
-  "/admin/test/customer-files/{customerFileId}":
+                - id: d04652ab-8ddb-411e-b683-53c25855f7a3
+                  regimeId: 34eb63e4-c538-48ca-9053-86164d12248c
+                  region: T
+                  fileReference: naltc50002
+                  createdAt: "2021-04-29T13:15:30.012Z"
+                  updatedAt: "2021-04-29T13:15:30.374Z"
+                  status: exported
+                  exportedAt: "2021-04-29T13:15:30.366Z"
+                - id: aed6eb7c-6876-4c32-a8a5-5bc84cf2b0f4
+                  regimeId: 34eb63e4-c538-48ca-9053-86164d12248c
+                  region: "Y"
+                  fileReference: nalyc50002
+                  createdAt: "2021-04-29T13:15:30.413Z"
+                  updatedAt: "2021-04-29T13:15:30.690Z"
+                  status: exported
+                  exportedAt: "2021-04-29T13:15:30.683Z"
+  /admin/test/customer-files/{customerFileId}:
     get:
       operationId: ViewCustomerFile
-      description: Request details of a 'customer file'. Returns the 'customer file'
-        record which details the file of customer changes the API generated and sent
-        to SSCL. It also lists
+      description: Request details of a 'customer file'. Returns the 'customer file' record which details the file of customer changes the API generated and sent to SSCL. It also lists
       tags:
-      - admin
+        - admin
       parameters:
-      - name: customerFileId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a customer
-          file
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a customer
-            file
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: customerFileId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a customer file
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a customer file
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -1120,71 +996,62 @@ paths:
                 type: object
                 properties:
                   id:
-                    description: Internal ID (GUID) allocated by the CM when creating
-                      a customer file
+                    description: Internal ID (GUID) allocated by the CM when creating a customer file
                     type: string
                     format: uuid
                     example: fd2ab097-3097-42bd-849e-046aa250a0d0
                   regimeId:
-                    description: Internal ID (GUID) allocated by the CM when creating
-                      a regime.
+                    description: Internal ID (GUID) allocated by the CM when creating a regime.
                     type: string
                     format: uuid
                     example: fd2ab097-3097-42bd-849e-046aa250a0d0
                   region:
-                    description: A single-digit region identifier for a transaction
-                      or customer
+                    description: A single-digit region identifier for a transaction or customer
                     type: string
                     enum:
-                    - A
-                    - B
-                    - E
-                    - N
-                    - S
-                    - T
-                    - W
-                    - Y
+                      - A
+                      - B
+                      - E
+                      - "N"
+                      - S
+                      - T
+                      - W
+                      - "Y"
                     example: A
                   fileReference:
-                    description: A 10-digit reference indicating the name of the customer
-                      file generated by the CM for notifying SSCL of new / updated
-                      customer records
+                    description: A 10-digit reference indicating the name of the customer file generated by the CM for notifying SSCL of new / updated customer records
                     type: string
                     example: nalsc50004
                   createdAt:
                     description: Date and time the record was created
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
                   updatedAt:
                     description: Date and time the record was last updated
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
                   status:
-                    description: Current status of the customer file. Note - if a
-                      file has a status of `pending` for more than a few minutes it
-                      is likely an issue as occurred during the generation
+                    description: Current status of the customer file. Note - if a file has a status of `pending` for more than a few minutes it is likely an issue as occurred during the generation
                     type: string
                     enum:
-                    - initialised
-                    - pending
-                    - exported
+                      - initialised
+                      - pending
+                      - exported
                     example: exported
                   exportedAt:
                     description: Date and time at which the customer file was generated
                     type: string
                     format: datetime
-                    example: '2020-09-11T11:56:41.578Z'
+                    example: "2020-09-11T11:56:41.578Z"
                   exportedCustomers:
                     type: array
                     items:
                       type: object
                       properties:
                         id:
-                          description: Internal ID (GUID) allocated by the CM when
-                            creating an exported customer record after having created
-                            a customer file
+                          description: Internal ID (GUID) allocated by the CM when creating an exported customer record after having created a customer file
                           type: string
                           format: uuid
                           example: fd2ab097-3097-42bd-849e-046aa250a0d0
@@ -1193,8 +1060,7 @@ paths:
                           type: string
                           example: B19120000A
                         customerFileId:
-                          description: Internal ID (GUID) allocated by the CM when
-                            creating a customer file
+                          description: Internal ID (GUID) allocated by the CM when creating a customer file
                           type: string
                           format: uuid
                           example: fd2ab097-3097-42bd-849e-046aa250a0d0
@@ -1202,33 +1068,33 @@ paths:
                           description: Date and time the record was created
                           type: string
                           format: datetime
-                          example: '2020-09-11T11:56:41.578Z'
+                          example: "2020-09-11T11:56:41.578Z"
                         updatedAt:
                           description: Date and time the record was last updated
                           type: string
                           format: datetime
-                          example: '2020-09-11T11:56:41.578Z'
+                          example: "2020-09-11T11:56:41.578Z"
               example:
                 id: d04652ab-8ddb-411e-b683-53c25855f7a3
                 regimeId: 34eb63e4-c538-48ca-9053-86164d12248c
                 region: T
                 fileReference: naltc50002
-                createdAt: '2021-04-29T13:15:30.012Z'
-                updatedAt: '2021-04-29T13:15:30.374Z'
+                createdAt: "2021-04-29T13:15:30.012Z"
+                updatedAt: "2021-04-29T13:15:30.374Z"
                 status: exported
-                exportedAt: '2021-04-29T13:15:30.366Z'
+                exportedAt: "2021-04-29T13:15:30.366Z"
                 exportedCustomers:
-                - id: 726a005e-341c-4da6-915c-c94cea87dd59
-                  customerReference: T12398729A
-                  customerFileId: d04652ab-8ddb-411e-b683-53c25855f7a3
-                  createdAt: '2021-04-29T13:15:30.358Z'
-                  updatedAt: '2021-04-29T13:15:30.358Z'
-                - id: 755dd2da-3be2-409f-83ec-c39ef48f664f
-                  customerReference: T32178999B
-                  customerFileId: d04652ab-8ddb-411e-b683-53c25855f7a3
-                  createdAt: '2021-04-29T13:15:30.358Z'
-                  updatedAt: '2021-04-29T13:15:30.358Z'
-        '404':
+                  - id: 726a005e-341c-4da6-915c-c94cea87dd59
+                    customerReference: T12398729A
+                    customerFileId: d04652ab-8ddb-411e-b683-53c25855f7a3
+                    createdAt: "2021-04-29T13:15:30.358Z"
+                    updatedAt: "2021-04-29T13:15:30.358Z"
+                  - id: 755dd2da-3be2-409f-83ec-c39ef48f664f
+                    customerReference: T32178999B
+                    customerFileId: d04652ab-8ddb-411e-b683-53c25855f7a3
+                    createdAt: "2021-04-29T13:15:30.358Z"
+                    updatedAt: "2021-04-29T13:15:30.358Z"
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -1237,40 +1103,37 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: No customer file found with id 8fb7e93c-1fc7-47cd-90d5-cdb1a8a63730
-  "/admin/test/data-export":
+  /admin/test/data-export:
     patch:
       operationId: DataExport
-      description: Manually trigger the data export process. This triggers creation
-        of CSV files of several database tables and sending of them to an S3 bucket.
+      description: Manually trigger the data export process. This triggers creation of CSV files of several database tables and sending of them to an S3 bucket.
       tags:
-      - admin
+        - admin
       responses:
-        '204':
+        "204":
           description: Success
-        '400':
+        "400":
           description: Failure
-  "/admin/test/transaction/{transactionId}":
+  /admin/test/transaction/{transactionId}:
     get:
       operationId: ViewTestTransaction
       description: |-
         Request to view _all_ data on a transaction. Includes bill run, invoice and licence details.
         > _The example provided only contains a subset of all the properties returned. It is intended to give just an indication of the structure._
       tags:
-      - admin
+        - admin
       parameters:
-      - name: transactionId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a transaction,
-          not necessarily visible to the user
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a transaction,
-            not necessarily visible to the user
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: transactionId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a transaction, not necessarily visible to the user
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a transaction, not necessarily visible to the user
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -1294,7 +1157,7 @@ paths:
                   billRunId: 647196ac-83a8-4f5a-8436-6a2dac00b72d
                   customerReference: TH230000222
                   financialYear: 2018
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -1303,31 +1166,28 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: No transaction found with id 323d6e4d-2703-4790-a1d5-81532d4291fd
-  "/v2/{regime}/bill-runs":
+  /v2/{regime}/bill-runs:
     post:
       operationId: CreateBillRun
-      description: This endpoint triggers creation of a bill run record for a region.
-        Bill run contains no transactions on creation.
+      description: This endpoint triggers creation of a bill run record for a region. Bill run contains no transactions on creation.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
       responses:
-        '201':
+        "201":
           description: Success
           content:
             application/json:
@@ -1338,14 +1198,12 @@ paths:
                     type: object
                     properties:
                       id:
-                        description: Internal ID (GUID) allocated by the CM when creating
-                          a bill run.
+                        description: Internal ID (GUID) allocated by the CM when creating a bill run.
                         type: string
                         format: uuid
                         example: fd2ab097-3097-42bd-849e-046aa250a0d0
                       billRunNumber:
-                        description: The five-digit bill run number of a bill run
-                          generated by the CM
+                        description: The five-digit bill run number of a bill run generated by the CM
                         type: integer
                         minimum: 10000
                         maximum: 99999
@@ -1354,7 +1212,7 @@ paths:
                 billRun:
                   id: 2bbbe459-966e-4026-b5d2-2f10867bdddd
                   billRunNumber: 10004
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -1363,7 +1221,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '422':
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -1372,8 +1230,7 @@ paths:
                   value:
                     statusCode: 422
                     error: Unprocessable Entity
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
-                      linked to regime wrls.
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
                 Missing region:
                   value:
                     statusCode: 422
@@ -1391,58 +1248,53 @@ paths:
               type: object
               properties:
                 region:
-                  description: A single-digit region identifier for a transaction
-                    or customer
+                  description: A single-digit region identifier for a transaction or customer
                   type: string
                   enum:
-                  - A
-                  - B
-                  - E
-                  - N
-                  - S
-                  - T
-                  - W
-                  - Y
+                    - A
+                    - B
+                    - E
+                    - "N"
+                    - S
+                    - T
+                    - W
+                    - "Y"
                   example: A
               required:
-              - region
+                - region
             example:
               region: A
-  "/v2/{regime}/bill-runs/{billRunId}/transactions":
+  /v2/{regime}/bill-runs/{billRunId}/transactions:
     post:
       operationId: AddBillRunTransaction
-      description: Triggers creation of a transaction and immediately adds it to the
-        specified bill run.
+      description: Triggers creation of a transaction and immediately adds it to the specified bill run.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '201':
+        "201":
           description: Success
           content:
             application/json:
@@ -1453,16 +1305,12 @@ paths:
                     type: object
                     properties:
                       id:
-                        description: Internal ID (GUID) allocated by the CM when creating
-                          a transaction, not necessarily visible to the user
+                        description: Internal ID (GUID) allocated by the CM when creating a transaction, not necessarily visible to the user
                         type: string
                         format: uuid
                         example: fd2ab097-3097-42bd-849e-046aa250a0d0
                       clientId:
-                        description: ID of the transaction in the client system. If
-                          provided at the time of creation the API will first check
-                          no existing transactions with the same ID for that regime
-                          exist.
+                        description: ID of the transaction in the client system. If provided at the time of creation the API will first check no existing transactions with the same ID for that regime exist.
                         type: string
                         nullable: true
                         example: hb3ab097-8567-42bd-849e-046aa250a8u8
@@ -1470,7 +1318,7 @@ paths:
                 transaction:
                   id: fd88e6c5-8da8-4e4f-b22f-c66554cd5bf3
                   clientId: 2395429b-e703-43bc-8522-ce3f67507ffa
-        '400':
+        "400":
           description: Failed - issue with the Rules Service
           content:
             application/json:
@@ -1485,7 +1333,7 @@ paths:
                     statusCode: 400
                     error: Bad Request
                     message: 'Rules service error: [error message]'
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -1494,7 +1342,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -1503,7 +1351,7 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
-        '409':
+        "409":
           description: Failed - the action conflicts with something
           content:
             application/json:
@@ -1512,16 +1360,14 @@ paths:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot
-                      be edited because its status is billed.
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be edited because its status is billed.
                 Client ID matches existing transaction:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: A transaction with Client ID '2395429b-e703-43bc-8522-ce3f67507ffa'
-                      for Regime 'wrls' already exists.
+                    message: A transaction with Client ID '2395429b-e703-43bc-8522-ce3f67507ffa' for Regime 'wrls' already exists.
                     clientId: 2395429b-e703-43bc-8522-ce3f67507ff
-        '422':
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -1530,8 +1376,7 @@ paths:
                   value:
                     statusCode: 422
                     error: Unprocessable Entity
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
-                      linked to regime wrls.
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
                 Ruleset not found:
                   value:
                     statusCode: 422
@@ -1562,14 +1407,11 @@ paths:
                   type: string
                   example: 31-MAR-2019
                 subjectToMinimumCharge:
-                  description: Boolean indicator to show whether a transaction is
-                    subject to minimum charge. For example, transactions for new licences
-                    are subject to minimum charge
+                  description: Boolean indicator to show whether a transaction is subject to minimum charge. For example, transactions for new licences are subject to minimum charge
                   type: boolean
                   example: false
                 credit:
-                  description: Boolean indicator to show whether the transaction is
-                    a credit (negative value)
+                  description: Boolean indicator to show whether the transaction is a credit (negative value)
                   type: boolean
                   example: false
                 billableDays:
@@ -1579,15 +1421,13 @@ paths:
                   maximum: 366
                   example: 149
                 authorisedDays:
-                  description: The number of days per year in which abstraction is
-                    authorised under the terms of the licence
+                  description: The number of days per year in which abstraction is authorised under the terms of the licence
                   type: integer
                   minimum: 0
                   maximum: 366
                   example: 214
                 volume:
-                  description: The volume (in thousands of cubic metres) on which
-                    the charge is based
+                  description: The volume (in thousands of cubic metres) on which the charge is based
                   type: number
                   minimum: 0
                   example: 19.909
@@ -1595,79 +1435,70 @@ paths:
                   description: Source on which standard charge calculation based
                   type: string
                   enum:
-                  - Supported
-                  - Kielder
-                  - Unsupported
-                  - Tidal
+                    - Supported
+                    - Kielder
+                    - Unsupported
+                    - Tidal
                   example: Unsupported
                 season:
                   description: Season on which charge calculation based
                   type: string
                   enum:
-                  - Summer
-                  - Winter
-                  - All Year
+                    - Summer
+                    - Winter
+                    - All Year
                   example: Summer
                 loss:
                   description: Loss on which charge calculation based
                   type: string
                   enum:
-                  - High
-                  - Medium
-                  - Low
-                  - Very Low
+                    - High
+                    - Medium
+                    - Low
+                    - Very Low
                   example: Medium
                 twoPartTariff:
-                  description: Boolean indicator to show whether the transaction is
-                    for the second part of a 2-part tariff charge
+                  description: Boolean indicator to show whether the transaction is for the second part of a 2-part tariff charge
                   type: boolean
                   example: true
                 compensationCharge:
-                  description: Boolean indicator to show whether the transaction relates
-                    to a compensation charge
+                  description: Boolean indicator to show whether the transaction relates to a compensation charge
                   type: boolean
                   example: false
                 eiucSource:
-                  description: Source on which compensation charge calculation based.
-                    This field is required when creating a transacton if `compensationCharge`
-                    is set to `true`
+                  description: Source on which compensation charge calculation based. This field is required when creating a transacton if `compensationCharge` is set to `true`
                   type: string
                   example: Tidal
                 waterUndertaker:
-                  description: Boolean indicator to show whether the transaction is
-                    for a water undertaker
+                  description: Boolean indicator to show whether the transaction is for a water undertaker
                   type: boolean
                   example: false
                 regionalChargingArea:
-                  description: The name of the region relevant to the determination
-                    of the SUC and / or EIUC value to be used in the calculation
+                  description: The name of the region relevant to the determination of the SUC and / or EIUC value to be used in the calculation
                   type: string
                   enum:
-                  - Anglian
-                  - Midlands
-                  - South West
-                  - North West
-                  - Southern
-                  - Thames
-                  - Northumbria
-                  - Yorkshire
-                  - Wales
+                    - Anglian
+                    - Midlands
+                    - South West
+                    - North West
+                    - Southern
+                    - Thames
+                    - Northumbria
+                    - Yorkshire
+                    - Wales
                   example: Northumbria
                 section126Factor:
-                  description: The factor to apply to the charge where a section 126
-                    charge agreement is relevant to the transaction
+                  description: The factor to apply to the charge where a section 126 charge agreement is relevant to the transaction
                   type: number
                   minimum: 0
                   maximum: 1
                   example: 0.75
                 section127Agreement:
-                  description: Indicator to show whether a section 127 charge agreement
-                    applies to the transaction
+                  description: Indicator to show whether a section 127 charge agreement applies to the transaction
                   type: boolean
                   example: false
                 section130Agreement:
-                  description: Indicator to show whether a section 130 charge agreement
-                    applies to the transaction
+                  description: Indicator to show whether a section 130 charge agreement applies to the transaction
                   type: boolean
                   example: true
                 customerReference:
@@ -1675,119 +1506,110 @@ paths:
                   type: string
                   example: B19120000A
                 lineDescription:
-                  description: Description of the reason for the charge, to appear
-                    on the invoice sent to the customer
+                  description: Description of the reason for the charge, to appear on the invoice sent to the customer
                   type: string
                   maxLength: 240
                   example: Borehole at Runhall, Norfolk.
                 licenceNumber:
-                  description: The reference of the licence to which a charge / transaction
-                    relates
+                  description: The reference of the licence to which a charge / transaction relates
                   type: string
                   maxLength: 150
                   example: 7/34/16/*G/0093
                 chargePeriod:
-                  description: The charge period for a transaction (i.e. charge period
-                    start date to charge period end date)
+                  description: The charge period for a transaction (i.e. charge period start date to charge period end date)
                   type: string
                   example: 01-APR-2018 - 31-MAR-2019
                 chargeElementId:
-                  description: An indicator (normally an integer) to distinguish between
-                    the different charge elements on a specific licence.
+                  description: An indicator (normally an integer) to distinguish between the different charge elements on a specific licence.
                   type: string
                   nullable: true
-                  example: '1'
+                  example: "1"
                 batchNumber:
-                  description: Number to be generated by WRLS indicating the 'batch'
-                    in which creation of a transaction was requested
+                  description: Number to be generated by WRLS indicating the 'batch' in which creation of a transaction was requested
                   type: string
                   nullable: true
                   example: TONY100
                 region:
-                  description: A single-digit region identifier for a transaction
-                    or customer
+                  description: A single-digit region identifier for a transaction or customer
                   type: string
                   enum:
-                  - A
-                  - B
-                  - E
-                  - N
-                  - S
-                  - T
-                  - W
-                  - Y
+                    - A
+                    - B
+                    - E
+                    - "N"
+                    - S
+                    - T
+                    - W
+                    - "Y"
                   example: A
                 areaCode:
-                  description: Code identifying the historic area (within a region)
-                    for the transaction.
+                  description: Code identifying the historic area (within a region) for the transaction.
                   type: string
                   enum:
-                  - ARCA
-                  - AREA
-                  - ARNA
-                  - CASC
-                  - MIDLS
-                  - MIDLT
-                  - MIDUS
-                  - MIDUT
-                  - AACOR
-                  - AADEV
-                  - AANWX
-                  - AASWX
-                  - NWCEN
-                  - NWNTH
-                  - NWSTH
-                  - HAAR
-                  - KAEA
-                  - SAAR
-                  - AGY2N
-                  - AGY2S
-                  - AGY3
-                  - AGY3N
-                  - AGY3S
-                  - AGY4N
-                  - AGY4S
-                  - N
-                  - SE
-                  - SE1
-                  - SE2
-                  - SW
-                  - ABNRTH
-                  - DALES
-                  - NAREA
-                  - RIDIN
-                  - DEFAULT
-                  - MULTI
+                    - ARCA
+                    - AREA
+                    - ARNA
+                    - CASC
+                    - MIDLS
+                    - MIDLT
+                    - MIDUS
+                    - MIDUT
+                    - AACOR
+                    - AADEV
+                    - AANWX
+                    - AASWX
+                    - NWCEN
+                    - NWNTH
+                    - NWSTH
+                    - HAAR
+                    - KAEA
+                    - SAAR
+                    - AGY2N
+                    - AGY2S
+                    - AGY3
+                    - AGY3N
+                    - AGY3S
+                    - AGY4N
+                    - AGY4S
+                    - "N"
+                    - SE
+                    - SE1
+                    - SE2
+                    - SW
+                    - ABNRTH
+                    - DALES
+                    - NAREA
+                    - RIDIN
+                    - DEFAULT
+                    - MULTI
                   example: NWCEN
                 clientId:
-                  description: ID of the transaction in the client system. If provided
-                    at the time of creation the API will first check no existing transactions
-                    with the same ID for that regime exist.
+                  description: ID of the transaction in the client system. If provided at the time of creation the API will first check no existing transactions with the same ID for that regime exist.
                   type: string
                   nullable: true
                   example: hb3ab097-8567-42bd-849e-046aa250a8u8
               required:
-              - region
-              - periodStart
-              - periodEnd
-              - customerReference
-              - licenceNumber
-              - billableDays
-              - authorisedDays
-              - volume
-              - source
-              - season
-              - loss
-              - section130Agreement
-              - section127Agreement
-              - twoPartTariff
-              - compensationCharge
-              - regionalChargingArea
-              - credit
-              - areaCode
-              - lineDescription
-              - waterUndertaker
-              - chargePeriod
+                - region
+                - periodStart
+                - periodEnd
+                - customerReference
+                - licenceNumber
+                - billableDays
+                - authorisedDays
+                - volume
+                - source
+                - season
+                - loss
+                - section130Agreement
+                - section127Agreement
+                - twoPartTariff
+                - compensationCharge
+                - regionalChargingArea
+                - credit
+                - areaCode
+                - lineDescription
+                - waterUndertaker
+                - chargePeriod
             example:
               periodStart: 01-APR-2019
               periodEnd: 31-MAR-2020
@@ -1795,7 +1617,7 @@ paths:
               credit: false
               billableDays: 310
               authorisedDays: 365
-              volume: '6.22'
+              volume: "6.22"
               source: Supported
               season: Summer
               loss: Low
@@ -1810,45 +1632,42 @@ paths:
               lineDescription: Well at Chigley Town Hall
               licenceNumber: TONY/TF9222/37
               chargePeriod: 01-APR-2018 - 31-MAR-2019
-              chargeElementId: ''
+              chargeElementId: ""
               batchNumber: TONY10
               region: W
               areaCode: ARCA
               clientId: 2395429b-e703-43bc-8522-ce3f67507ffa
-  "/v2/{regime}/bill-runs/{billRunId}":
+  /v2/{regime}/bill-runs/{billRunId}:
     get:
       operationId: ViewBillRun
       description: Request to view a single bill run based on the bill run ID.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -1859,44 +1678,40 @@ paths:
                     type: object
                     properties:
                       id:
-                        description: Internal ID (GUID) allocated by the CM when creating
-                          a bill run.
+                        description: Internal ID (GUID) allocated by the CM when creating a bill run.
                         type: string
                         format: uuid
                         example: fd2ab097-3097-42bd-849e-046aa250a0d0
                       billRunNumber:
-                        description: The five-digit bill run number of a bill run
-                          generated by the CM
+                        description: The five-digit bill run number of a bill run generated by the CM
                         type: integer
                         minimum: 10000
                         maximum: 99999
                         example: 14283
                       region:
-                        description: A single-digit region identifier for a transaction
-                          or customer
+                        description: A single-digit region identifier for a transaction or customer
                         type: string
                         enum:
-                        - A
-                        - B
-                        - E
-                        - N
-                        - S
-                        - T
-                        - W
-                        - Y
+                          - A
+                          - B
+                          - E
+                          - "N"
+                          - S
+                          - T
+                          - W
+                          - "Y"
                         example: A
                       status:
-                        description: Indicator to show the progress of a bill run
-                          towards billed status
+                        description: Indicator to show the progress of a bill run towards billed status
                         type: string
                         enum:
-                        - approved
-                        - billed
-                        - billing_not_required
-                        - generating
-                        - generated
-                        - initialised
-                        - pending
+                          - approved
+                          - billed
+                          - billing_not_required
+                          - generating
+                          - generated
+                          - initialised
+                          - pending
                         example: billed
                       creditNoteCount:
                         description: Total number of credit notes in the bill run
@@ -1921,9 +1736,7 @@ paths:
                         type: number
                         example: 573.45
                       transactionFileReference:
-                        description: A 10-digit reference indicating the name of the
-                          transaction file generated by the CM in which the transaction
-                          has been included
+                        description: A 10-digit reference indicating the name of the transaction file generated by the CM in which the transaction has been included
                         type: string
                         maxLength: 10
                         example: nalbi50023
@@ -1933,8 +1746,7 @@ paths:
                           type: object
                           properties:
                             id:
-                              description: Internal ID (GUID) allocated by the CM
-                                when creating an invoice.
+                              description: Internal ID (GUID) allocated by the CM when creating an invoice.
                               type: string
                               format: uuid
                               example: fd2ab097-3097-42bd-849e-046aa250a0d0
@@ -1943,34 +1755,24 @@ paths:
                               type: string
                               example: B19120000A
                             financialYear:
-                              description: The financial year (1 April to 31 March)
-                                within which the charge period of a transaction falls
+                              description: The financial year (1 April to 31 March) within which the charge period of a transaction falls
                               type: integer
                               minimum: 2014
                               example: 2019
                             deminimisInvoice:
-                              description: Boolean flag to indicate whether an invoice
-                                will not be charged to the customer due to falling
-                                below the de-minimis value of £5
+                              description: Boolean flag to indicate whether an invoice will not be charged to the customer due to falling below the de-minimis value of £5
                               type: boolean
                               example: false
                             zeroValueInvoice:
-                              description: Boolean flag to indicate whether the total
-                                value of the invoice is £0. These invoices will not
-                                be included in the bill run files we generate
+                              description: Boolean flag to indicate whether the total value of the invoice is £0. These invoices will not be included in the bill run files we generate
                               type: boolean
                               example: false
                             minimumChargeInvoice:
-                              description: Boolean indicator to show whether an invoice
-                                contains minimum charge transactions which were generated
-                                by the CM
+                              description: Boolean indicator to show whether an invoice contains minimum charge transactions which were generated by the CM
                               type: boolean
                               example: false
                             transactionReference:
-                              description: A 10-digit reference which will be used
-                                as the invoice number on the invoice dispatched to
-                                the customer. Ref is allocated by the CM when a bill
-                                run is 'sent'
+                              description: A 10-digit reference which will be used as the invoice number on the invoice dispatched to the customer. Ref is allocated by the CM when a bill run is 'sent'
                               type: string
                               example: BAI1273369
                             creditLineValue:
@@ -1986,21 +1788,15 @@ paths:
                               type: number
                               example: 573.45
                             rebilledType:
-                              description: The type of invoice in relation to rebilling.
-                                `O` (Original) means the invoice is not a result of
-                                rebilling. `C` (Cancel) is an invoice generated as
-                                a result of rebilling to 'cancel' the original invoice.
-                                `R` (Rebill) is the invoice generated to 'rebill'
-                                the original invoice.
+                              description: The type of invoice in relation to rebilling. `O` (Original) means the invoice is not a result of rebilling. `C` (Cancel) is an invoice generated as a result of rebilling to 'cancel' the original invoice. `R` (Rebill) is the invoice generated to 'rebill' the original invoice.
                               type: string
                               enum:
-                              - C
-                              - O
-                              - R
+                                - C
+                                - O
+                                - R
                               example: R
                             rebilledInvoiceId:
-                              description: If a rebilled invoice this is the ID of
-                                the originating invoice. Else will default to '99999999-9999-9999-9999-999999999999'
+                              description: If a rebilled invoice this is the ID of the originating invoice. Else will default to '99999999-9999-9999-9999-999999999999'
                               type: string
                               format: uuid
                               example: 99999999-9999-9999-9999-999999999999
@@ -2010,14 +1806,12 @@ paths:
                                 type: object
                                 properties:
                                   id:
-                                    description: Internal ID (GUID) allocated by the
-                                      CM when creating a licence.
+                                    description: Internal ID (GUID) allocated by the CM when creating a licence.
                                     type: string
                                     format: uuid
                                     example: fd2ab097-3097-42bd-849e-046aa250a0d0
                                   licenceNumber:
-                                    description: The reference of the licence to which
-                                      a charge / transaction relates
+                                    description: The reference of the licence to which a charge / transaction relates
                                     type: string
                                     maxLength: 150
                                     example: 7/34/16/*G/0093
@@ -2034,7 +1828,7 @@ paths:
                       invoiceCount: 0
                       invoiceValue: 0
                       netTotal: 0
-                      transactionFileReference: ''
+                      transactionFileReference: ""
                       invoices: []
                 02 Transactions added:
                   value:
@@ -2048,25 +1842,25 @@ paths:
                       invoiceCount: 0
                       invoiceValue: 0
                       netTotal: 2500
-                      transactionFileReference: ''
+                      transactionFileReference: ""
                       invoices:
-                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
-                        customerReference: TH150000020
-                        financialYear: 2019
-                        deminimisInvoice: false
-                        zeroValueInvoice: false
-                        minimumChargeInvoice: false
-                        transactionReference: ''
-                        creditLineValue: 0
-                        debitLineValue: 2500
-                        netTotal: 2500
-                        rebilledType: O
-                        rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
-                        licences:
-                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
-                          licenceNumber: FOOO/BARRR/306
-                        - id: 77502697-e274-491a-bd6d-84ec557b0485
-                          licenceNumber: FOOO/BARRR/307
+                        - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                          customerReference: TH150000020
+                          financialYear: 2019
+                          deminimisInvoice: false
+                          zeroValueInvoice: false
+                          minimumChargeInvoice: false
+                          transactionReference: ""
+                          creditLineValue: 0
+                          debitLineValue: 2500
+                          netTotal: 2500
+                          rebilledType: O
+                          rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
+                          licences:
+                            - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                              licenceNumber: FOOO/BARRR/306
+                            - id: 77502697-e274-491a-bd6d-84ec557b0485
+                              licenceNumber: FOOO/BARRR/307
                 03 Generating bill run:
                   value:
                     billRun:
@@ -2079,25 +1873,25 @@ paths:
                       invoiceCount: 0
                       invoiceValue: 0
                       netTotal: 2500
-                      transactionFileReference: ''
+                      transactionFileReference: ""
                       invoices:
-                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
-                        customerReference: TH150000020
-                        financialYear: 2019
-                        deminimisInvoice: false
-                        zeroValueInvoice: false
-                        minimumChargeInvoice: false
-                        transactionReference: ''
-                        creditLineValue: 0
-                        debitLineValue: 2500
-                        netTotal: 2500
-                        rebilledType: O
-                        rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
-                        licences:
-                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
-                          licenceNumber: FOOO/BARRR/306
-                        - id: 77502697-e274-491a-bd6d-84ec557b0485
-                          licenceNumber: FOOO/BARRR/307
+                        - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                          customerReference: TH150000020
+                          financialYear: 2019
+                          deminimisInvoice: false
+                          zeroValueInvoice: false
+                          minimumChargeInvoice: false
+                          transactionReference: ""
+                          creditLineValue: 0
+                          debitLineValue: 2500
+                          netTotal: 2500
+                          rebilledType: O
+                          rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
+                          licences:
+                            - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                              licenceNumber: FOOO/BARRR/306
+                            - id: 77502697-e274-491a-bd6d-84ec557b0485
+                              licenceNumber: FOOO/BARRR/307
                 04 Bill run generated:
                   value:
                     billRun:
@@ -2110,25 +1904,25 @@ paths:
                       invoiceCount: 1
                       invoiceValue: 2500
                       netTotal: 2500
-                      transactionFileReference: ''
+                      transactionFileReference: ""
                       invoices:
-                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
-                        customerReference: TH150000020
-                        financialYear: 2019
-                        deminimisInvoice: false
-                        zeroValueInvoice: false
-                        minimumChargeInvoice: false
-                        transactionReference: ''
-                        creditLineValue: 0
-                        debitLineValue: 2500
-                        netTotal: 2500
-                        rebilledType: O
-                        rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
-                        licences:
-                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
-                          licenceNumber: FOOO/BARRR/306
-                        - id: 77502697-e274-491a-bd6d-84ec557b0485
-                          licenceNumber: FOOO/BARRR/307
+                        - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                          customerReference: TH150000020
+                          financialYear: 2019
+                          deminimisInvoice: false
+                          zeroValueInvoice: false
+                          minimumChargeInvoice: false
+                          transactionReference: ""
+                          creditLineValue: 0
+                          debitLineValue: 2500
+                          netTotal: 2500
+                          rebilledType: O
+                          rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
+                          licences:
+                            - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                              licenceNumber: FOOO/BARRR/306
+                            - id: 77502697-e274-491a-bd6d-84ec557b0485
+                              licenceNumber: FOOO/BARRR/307
                 05 Approved:
                   value:
                     billRun:
@@ -2141,25 +1935,25 @@ paths:
                       invoiceCount: 1
                       invoiceValue: 2500
                       netTotal: 2500
-                      transactionFileReference: ''
+                      transactionFileReference: ""
                       invoices:
-                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
-                        customerReference: TH150000020
-                        financialYear: 2019
-                        deminimisInvoice: false
-                        zeroValueInvoice: false
-                        minimumChargeInvoice: false
-                        transactionReference: ''
-                        creditLineValue: 0
-                        debitLineValue: 2500
-                        netTotal: 2500
-                        rebilledType: O
-                        rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
-                        licences:
-                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
-                          licenceNumber: FOOO/BARRR/306
-                        - id: 77502697-e274-491a-bd6d-84ec557b0485
-                          licenceNumber: FOOO/BARRR/307
+                        - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                          customerReference: TH150000020
+                          financialYear: 2019
+                          deminimisInvoice: false
+                          zeroValueInvoice: false
+                          minimumChargeInvoice: false
+                          transactionReference: ""
+                          creditLineValue: 0
+                          debitLineValue: 2500
+                          netTotal: 2500
+                          rebilledType: O
+                          rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
+                          licences:
+                            - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                              licenceNumber: FOOO/BARRR/306
+                            - id: 77502697-e274-491a-bd6d-84ec557b0485
+                              licenceNumber: FOOO/BARRR/307
                 06 Sent:
                   value:
                     billRun:
@@ -2174,23 +1968,23 @@ paths:
                       netTotal: 2500
                       transactionFileReference: nalwi50001
                       invoices:
-                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
-                        customerReference: TH150000020
-                        financialYear: 2019
-                        deminimisInvoice: false
-                        zeroValueInvoice: false
-                        minimumChargeInvoice: false
-                        transactionReference: AAI1000008
-                        creditLineValue: 0
-                        debitLineValue: 2500
-                        netTotal: 2500
-                        rebilledType: O
-                        rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
-                        licences:
-                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
-                          licenceNumber: FOOO/BARRR/306
-                        - id: 77502697-e274-491a-bd6d-84ec557b0485
-                          licenceNumber: FOOO/BARRR/307
+                        - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                          customerReference: TH150000020
+                          financialYear: 2019
+                          deminimisInvoice: false
+                          zeroValueInvoice: false
+                          minimumChargeInvoice: false
+                          transactionReference: AAI1000008
+                          creditLineValue: 0
+                          debitLineValue: 2500
+                          netTotal: 2500
+                          rebilledType: O
+                          rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
+                          licences:
+                            - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                              licenceNumber: FOOO/BARRR/306
+                            - id: 77502697-e274-491a-bd6d-84ec557b0485
+                              licenceNumber: FOOO/BARRR/307
                 07 Billed:
                   value:
                     billRun:
@@ -2205,24 +1999,24 @@ paths:
                       netTotal: 2500
                       transactionFileReference: nalwi50001
                       invoices:
-                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
-                        customerReference: TH150000020
-                        financialYear: 2019
-                        deminimisInvoice: false
-                        zeroValueInvoice: false
-                        minimumChargeInvoice: false
-                        transactionReference: AAI1000008
-                        creditLineValue: 0
-                        debitLineValue: 2500
-                        netTotal: 2500
-                        rebilledType: O
-                        rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
-                        licences:
-                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
-                          licenceNumber: FOOO/BARRR/306
-                        - id: 77502697-e274-491a-bd6d-84ec557b0485
-                          licenceNumber: FOOO/BARRR/307
-                '08 Billing not required':
+                        - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                          customerReference: TH150000020
+                          financialYear: 2019
+                          deminimisInvoice: false
+                          zeroValueInvoice: false
+                          minimumChargeInvoice: false
+                          transactionReference: AAI1000008
+                          creditLineValue: 0
+                          debitLineValue: 2500
+                          netTotal: 2500
+                          rebilledType: O
+                          rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
+                          licences:
+                            - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                              licenceNumber: FOOO/BARRR/306
+                            - id: 77502697-e274-491a-bd6d-84ec557b0485
+                              licenceNumber: FOOO/BARRR/307
+                08 Billing not required:
                   value:
                     billRun:
                       id: fd2ab097-3097-42bd-849e-046aa250a0d0
@@ -2234,26 +2028,26 @@ paths:
                       invoiceCount: 0
                       invoiceValue: 0
                       netTotal: 0
-                      transactionFileReference: ''
+                      transactionFileReference: ""
                       invoices:
-                      - id: aa630ae0-0e51-4166-9025-66576c513f7f
-                        customerReference: TH150000020
-                        financialYear: 2019
-                        deminimisInvoice: false
-                        zeroValueInvoice: false
-                        minimumChargeInvoice: false
-                        transactionReference: ''
-                        creditLineValue: 2500
-                        debitLineValue: 2500
-                        netTotal: 0
-                        rebilledType: O
-                        rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
-                        licences:
-                        - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
-                          licenceNumber: FOOO/BARRR/306
-                        - id: 77502697-e274-491a-bd6d-84ec557b0485
-                          licenceNumber: FOOO/BARRR/307
-        '403':
+                        - id: aa630ae0-0e51-4166-9025-66576c513f7f
+                          customerReference: TH150000020
+                          financialYear: 2019
+                          deminimisInvoice: false
+                          zeroValueInvoice: false
+                          minimumChargeInvoice: false
+                          transactionReference: ""
+                          creditLineValue: 2500
+                          debitLineValue: 2500
+                          netTotal: 0
+                          rebilledType: O
+                          rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
+                          licences:
+                            - id: 3bde68ad-f55e-4a15-b1d8-c2fcd0a95fea
+                              licenceNumber: FOOO/BARRR/306
+                            - id: 77502697-e274-491a-bd6d-84ec557b0485
+                              licenceNumber: FOOO/BARRR/307
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -2262,7 +2056,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -2271,7 +2065,7 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
-        '422':
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -2279,44 +2073,39 @@ paths:
                 example:
                   statusCode: 422
                   error: Unprocessable Entity
-                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked
-                    to regime wrls.
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
     delete:
       operationId: DeleteBillRun
-      description: Deletes a specified bill run and all invoices, licences, and transactions
-        linked to it. Bill run must be unbilled.
+      description: Deletes a specified bill run and all invoices, licences, and transactions linked to it. Bill run must be unbilled.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '204':
+        "204":
           description: Success
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -2325,7 +2114,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -2334,7 +2123,7 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
-        '409':
+        "409":
           description: Failed - the action conflicts with something
           content:
             application/json:
@@ -2342,9 +2131,8 @@ paths:
                 example:
                   statusCode: 409
                   error: Conflict
-                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be
-                    edited because its status is billed.
-        '422':
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be edited because its status is billed.
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -2352,45 +2140,40 @@ paths:
                 example:
                   statusCode: 422
                   error: Unprocessable Entity
-                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked
-                    to regime wrls.
-  "/v2/{regime}/bill-runs/{billRunId}/generate":
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
+  /v2/{regime}/bill-runs/{billRunId}/generate:
     patch:
       operationId: GenerateBillRun
-      description: Generate the summary for the specified bill run. Bill run must
-        be unbilled. Must take place before bill run is sent.
+      description: Generate the summary for the specified bill run. Bill run must be unbilled. Must take place before bill run is sent.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '204':
+        "204":
           description: Success
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -2399,7 +2182,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -2408,7 +2191,7 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
-        '409':
+        "409":
           description: Failed - the action conflicts with something
           content:
             application/json:
@@ -2417,21 +2200,18 @@ paths:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot
-                      be patched because its status is billed.
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be patched because its status is billed.
                 Bill run is already generating:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0
-                      is already being generated
+                    message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is already being generated
                 Bill run is already generated:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0
-                      has already been generated.
-        '422':
+                    message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0 has already been generated.
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -2440,51 +2220,43 @@ paths:
                   value:
                     statusCode: 422
                     error: Unprocessable Entity
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
-                      linked to regime wrls.
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
                 No transactions:
                   value:
                     statusCode: 422
                     error: Unprocessable Entity
-                    message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0
-                      cannot be generated because it has no transactions
-  "/v2/{regime}/bill-runs/{billRunId}/status":
+                    message: Summary for bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be generated because it has no transactions
+  /v2/{regime}/bill-runs/{billRunId}/status:
     get:
       operationId: ViewBillRunStatus
-      description: Request to view the status of a single bill run based on the bill
-        run ID. It is intended to help client systems quickly determine if a bill
-        run is ready to be viewed after a `/generate` request and reduce the load
-        on the API.
+      description: Request to view the status of a single bill run based on the bill run ID. It is intended to help client systems quickly determine if a bill run is ready to be viewed after a `/generate` request and reduce the load on the API.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -2492,17 +2264,16 @@ paths:
                 type: object
                 properties:
                   status:
-                    description: Indicator to show the progress of a bill run towards
-                      billed status
+                    description: Indicator to show the progress of a bill run towards billed status
                     type: string
                     enum:
-                    - approved
-                    - billed
-                    - billing_not_required
-                    - generating
-                    - generated
-                    - initialised
-                    - pending
+                      - approved
+                      - billed
+                      - billing_not_required
+                      - generating
+                      - generated
+                      - initialised
+                      - pending
                     example: billed
               examples:
                 01 Just created:
@@ -2526,10 +2297,10 @@ paths:
                 07 Billed:
                   value:
                     status: billed
-                '08 Not billed':
+                08 Not billed:
                   value:
                     status: billing_not_required
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -2538,7 +2309,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -2547,7 +2318,7 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
-        '422':
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -2555,45 +2326,40 @@ paths:
                 example:
                   statusCode: 422
                   error: Unprocessable Entity
-                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked
-                    to regime wrls.
-  "/v2/{regime}/bill-runs/{billRunId}/approve":
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
+  /v2/{regime}/bill-runs/{billRunId}/approve:
     patch:
       operationId: ApproveBillRun
-      description: Approves a specified bill run. Bill run must have a status of 'generated'.
-        Must take place before bill run is sent.
+      description: Approves a specified bill run. Bill run must have a status of 'generated'. Must take place before bill run is sent.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '204':
+        "204":
           description: Success
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -2602,7 +2368,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -2611,7 +2377,7 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
-        '409':
+        "409":
           description: Failed - the action conflicts with something
           content:
             application/json:
@@ -2620,15 +2386,13 @@ paths:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot
-                      be patched because its status is billed.
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be patched because its status is billed.
                 Bill run is not generated:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not
-                      have a status of 'generated'.
-        '422':
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not have a status of 'generated'.
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -2637,9 +2401,8 @@ paths:
                   value:
                     statusCode: 422
                     error: Unprocessable Entity
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
-                      linked to regime wrls.
-  "/v2/{regime}/bill-runs/{billRunId}/send":
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
+  /v2/{regime}/bill-runs/{billRunId}/send:
     patch:
       operationId: SendBillRun
       description: |
@@ -2742,37 +2505,34 @@ paths:
         | 4  | `31517` | Invoice value |
         | 5  | `0` | Credit note value (signed) |
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '204':
+        "204":
           description: Success
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -2781,7 +2541,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -2790,7 +2550,7 @@ paths:
                   statusCode: 404
                   error: Not found
                   message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
-        '409':
+        "409":
           description: Failed - the action conflicts with something
           content:
             application/json:
@@ -2799,15 +2559,13 @@ paths:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot
-                      be patched because its status is billed.
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be patched because its status is billed.
                 Bill run is not approved:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not
-                      have a status of 'approved'.
-        '422':
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 does not have a status of 'approved'.
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -2816,53 +2574,47 @@ paths:
                   value:
                     statusCode: 422
                     error: Unprocessable Entity
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
-                      linked to regime wrls.
-  "/v2/{regime}/bill-runs/{billRunId}/invoices/{invoiceId}":
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
+  /v2/{regime}/bill-runs/{billRunId}/invoices/{invoiceId}:
     get:
       operationId: ViewBillRunInvoice
-      description: Request to view details of an invoice. Returns information about
-        the invoice, each of the licences linked to it, and all transactions linked
-        to each licence.
+      description: Request to view details of an invoice. Returns information about the invoice, each of the licences linked to it, and all transactions linked to each licence.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
-      - name: invoiceId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating an invoice.
-        schema:
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: invoiceId
+          in: path
+          required: true
           description: Internal ID (GUID) allocated by the CM when creating an invoice.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating an invoice.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -2870,14 +2622,12 @@ paths:
                 type: object
                 properties:
                   id:
-                    description: Internal ID (GUID) allocated by the CM when creating
-                      an invoice.
+                    description: Internal ID (GUID) allocated by the CM when creating an invoice.
                     type: string
                     format: uuid
                     example: fd2ab097-3097-42bd-849e-046aa250a0d0
                   billRunId:
-                    description: Internal ID (GUID) allocated by the CM when creating
-                      a bill run.
+                    description: Internal ID (GUID) allocated by the CM when creating a bill run.
                     type: string
                     format: uuid
                     example: fd2ab097-3097-42bd-849e-046aa250a0d0
@@ -2886,32 +2636,24 @@ paths:
                     type: string
                     example: B19120000A
                   financialYear:
-                    description: The financial year (1 April to 31 March) within which
-                      the charge period of a transaction falls
+                    description: The financial year (1 April to 31 March) within which the charge period of a transaction falls
                     type: integer
                     minimum: 2014
                     example: 2019
                   deminimisInvoice:
-                    description: Boolean flag to indicate whether an invoice will
-                      not be charged to the customer due to falling below the de-minimis
-                      value of £5
+                    description: Boolean flag to indicate whether an invoice will not be charged to the customer due to falling below the de-minimis value of £5
                     type: boolean
                     example: false
                   zeroValueInvoice:
-                    description: Boolean flag to indicate whether the total value
-                      of the invoice is £0. These invoices will not be included in
-                      the bill run files we generate
+                    description: Boolean flag to indicate whether the total value of the invoice is £0. These invoices will not be included in the bill run files we generate
                     type: boolean
                     example: false
                   minimumChargeInvoice:
-                    description: Boolean indicator to show whether an invoice contains
-                      minimum charge transactions which were generated by the CM
+                    description: Boolean indicator to show whether an invoice contains minimum charge transactions which were generated by the CM
                     type: boolean
                     example: false
                   transactionReference:
-                    description: A 10-digit reference which will be used as the invoice
-                      number on the invoice dispatched to the customer. Ref is allocated
-                      by the CM when a bill run is 'sent'
+                    description: A 10-digit reference which will be used as the invoice number on the invoice dispatched to the customer. Ref is allocated by the CM when a bill run is 'sent'
                     type: string
                     example: BAI1273369
                   creditLineValue:
@@ -2927,20 +2669,15 @@ paths:
                     type: number
                     example: 573.45
                   rebilledType:
-                    description: The type of invoice in relation to rebilling. `O`
-                      (Original) means the invoice is not a result of rebilling. `C`
-                      (Cancel) is an invoice generated as a result of rebilling to
-                      'cancel' the original invoice. `R` (Rebill) is the invoice generated
-                      to 'rebill' the original invoice.
+                    description: The type of invoice in relation to rebilling. `O` (Original) means the invoice is not a result of rebilling. `C` (Cancel) is an invoice generated as a result of rebilling to 'cancel' the original invoice. `R` (Rebill) is the invoice generated to 'rebill' the original invoice.
                     type: string
                     enum:
-                    - C
-                    - O
-                    - R
+                      - C
+                      - O
+                      - R
                     example: R
                   rebilledInvoiceId:
-                    description: If a rebilled invoice this is the ID of the originating
-                      invoice. Else will default to '99999999-9999-9999-9999-999999999999'
+                    description: If a rebilled invoice this is the ID of the originating invoice. Else will default to '99999999-9999-9999-9999-999999999999'
                     type: string
                     format: uuid
                     example: 99999999-9999-9999-9999-999999999999
@@ -2950,14 +2687,12 @@ paths:
                       type: object
                       properties:
                         id:
-                          description: Internal ID (GUID) allocated by the CM when
-                            creating a licence.
+                          description: Internal ID (GUID) allocated by the CM when creating a licence.
                           type: string
                           format: uuid
                           example: fd2ab097-3097-42bd-849e-046aa250a0d0
                         licenceNumber:
-                          description: The reference of the licence to which a charge
-                            / transaction relates
+                          description: The reference of the licence to which a charge / transaction relates
                           type: string
                           maxLength: 150
                           example: 7/34/16/*G/0093
@@ -2971,66 +2706,50 @@ paths:
                             type: object
                             properties:
                               id:
-                                description: Internal ID (GUID) allocated by the CM
-                                  when creating a transaction, not necessarily visible
-                                  to the user
+                                description: Internal ID (GUID) allocated by the CM when creating a transaction, not necessarily visible to the user
                                 type: string
                                 format: uuid
                                 example: fd2ab097-3097-42bd-849e-046aa250a0d0
                               clientId:
-                                description: ID of the transaction in the client system.
-                                  If provided at the time of creation the API will
-                                  first check no existing transactions with the same
-                                  ID for that regime exist.
+                                description: ID of the transaction in the client system. If provided at the time of creation the API will first check no existing transactions with the same ID for that regime exist.
                                 type: string
                                 nullable: true
                                 example: hb3ab097-8567-42bd-849e-046aa250a8u8
                               chargeValue:
-                                description: The value of the transaction in pence
-                                  based on the response from the rules service
+                                description: The value of the transaction in pence based on the response from the rules service
                                 type: number
                                 example: 9290
                               credit:
-                                description: Boolean indicator to show whether the
-                                  transaction is a credit
+                                description: Boolean indicator to show whether the transaction is a credit
                                 type: boolean
                                 example: false
                               subjectToMinimumCharge:
-                                description: Boolean indicator to show whether a transaction
-                                  is subject to minimum charge. For example, transactions
-                                  for new licences are subject to minimum charge
+                                description: Boolean indicator to show whether a transaction is subject to minimum charge. For example, transactions for new licences are subject to minimum charge
                                 type: boolean
                                 example: false
                               minimumChargeAdjustment:
-                                description: Boolean indicator to show whether a transaction
-                                  is a minimum charge transaction generated by the
-                                  CM
+                                description: Boolean indicator to show whether a transaction is a minimum charge transaction generated by the CM
                                 type: boolean
                                 example: false
                               lineDescription:
-                                description: Description of the reason for the charge,
-                                  to appear on the invoice sent to the customer
+                                description: Description of the reason for the charge, to appear on the invoice sent to the customer
                                 type: string
                                 maxLength: 240
                                 example: Borehole at Runhall, Norfolk.
                               periodStart:
-                                description: The start date of the charge period covered
-                                  by a transaction
+                                description: The start date of the charge period covered by a transaction
                                 type: string
                                 example: 01-APR-2018
                               periodEnd:
-                                description: The end date of the charge period covered
-                                  by a transaction
+                                description: The end date of the charge period covered by a transaction
                                 type: string
                                 example: 31-MAR-2019
                               compensationCharge:
-                                description: Boolean indicator to show whether the
-                                  transaction relates to a compensation charge
+                                description: Boolean indicator to show whether the transaction relates to a compensation charge
                                 type: boolean
                                 example: false
                               calculation:
-                                description: Copy of the Rules service JSON response
-                                  for audit/reference purposes
+                                description: Copy of the Rules service JSON response for audit/reference purposes
                                 type: object
               example:
                 invoice:
@@ -3041,57 +2760,57 @@ paths:
                   deminimisInvoice: false
                   zeroValueInvoice: false
                   minimumChargeInvoice: false
-                  transactionReference:
+                  transactionReference: null
                   creditLineValue: 2093
                   debitLineValue: 0
                   netTotal: -2093
                   rebilledType: O
                   rebilledInvoiceId: 99999999-9999-9999-9999-999999999999
                   licences:
-                  - id: f62faabc-d65e-4242-a106-9777c1d57db7
-                    licenceNumber: TONY/TF9222/38
-                    netTotal: -2093
-                    transactions:
-                    - id: 64eebf4e-9400-469b-9fa3-a3f6506b2375
-                      clientId:
-                      chargeValue: 2093
-                      credit: true
-                      subjectToMinimumCharge: false
-                      minimumChargeAdjustment: false
-                      lineDescription: Well at Chigley Town Hall
-                      periodStart: '2018-04-01T00:00:00.000Z'
-                      periodEnd: '2019-03-31T00:00:00.000Z'
-                      compensationCharge: false
-                      calculation:
-                        __DecisionID__: ba31bd7b-a13e-4820-b15d-6f70fb2c52490
-                        WRLSChargingResponse:
-                          chargeValue: 20.93
-                          decisionPoints:
-                            sourceFactor: 18.66
-                            seasonFactor: 29.856
-                            lossFactor: 0.89568
-                            volumeFactor: 6.22
-                            abatementAdjustment: 24.640156800000003
-                            s127Agreement: 24.640156800000003
-                            s130Agreement: 24.640156800000003
-                            secondPartCharge: false
-                            waterUndertaker: false
-                            eiucFactor: 0
-                            compensationCharge: false
-                            eiucSourceFactor: 0
-                            sucFactor: 24.640156800000003
-                          messages: []
-                          sucFactor: 27.51
-                          volumeFactor: 6.22
-                          sourceFactor: 3
-                          seasonFactor: 1.6
-                          lossFactor: 0.03
-                          abatementAdjustment: S126 x 1.0
-                          s127Agreement:
-                          s130Agreement:
-                          eiucSourceFactor: 0
-                          eiucFactor: 0
-        '403':
+                    - id: f62faabc-d65e-4242-a106-9777c1d57db7
+                      licenceNumber: TONY/TF9222/38
+                      netTotal: -2093
+                      transactions:
+                        - id: 64eebf4e-9400-469b-9fa3-a3f6506b2375
+                          clientId: null
+                          chargeValue: 2093
+                          credit: true
+                          subjectToMinimumCharge: false
+                          minimumChargeAdjustment: false
+                          lineDescription: Well at Chigley Town Hall
+                          periodStart: "2018-04-01T00:00:00.000Z"
+                          periodEnd: "2019-03-31T00:00:00.000Z"
+                          compensationCharge: false
+                          calculation:
+                            __DecisionID__: ba31bd7b-a13e-4820-b15d-6f70fb2c52490
+                            WRLSChargingResponse:
+                              chargeValue: 20.93
+                              decisionPoints:
+                                sourceFactor: 18.66
+                                seasonFactor: 29.856
+                                lossFactor: 0.89568
+                                volumeFactor: 6.22
+                                abatementAdjustment: 24.640156800000003
+                                s127Agreement: 24.640156800000003
+                                s130Agreement: 24.640156800000003
+                                secondPartCharge: false
+                                waterUndertaker: false
+                                eiucFactor: 0
+                                compensationCharge: false
+                                eiucSourceFactor: 0
+                                sucFactor: 24.640156800000003
+                              messages: []
+                              sucFactor: 27.51
+                              volumeFactor: 6.22
+                              sourceFactor: 3
+                              seasonFactor: 1.6
+                              lossFactor: 0.03
+                              abatementAdjustment: S126 x 1.0
+                              s127Agreement: null
+                              s130Agreement: null
+                              eiucSourceFactor: 0
+                              eiucFactor: 0
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -3100,7 +2819,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -3115,7 +2834,7 @@ paths:
                     statusCode: 404
                     error: Not found
                     message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
-        '409':
+        "409":
           description: Failed - the invoice is not linked to that bill run
           content:
             application/json:
@@ -3123,9 +2842,8 @@ paths:
                 example:
                   statusCode: 409
                   error: Conflict
-                  message: Invoice db82bf38-638a-44d3-b1b3-1ae8524d9c38 is not linked
-                    to bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9.
-        '422':
+                  message: Invoice db82bf38-638a-44d3-b1b3-1ae8524d9c38 is not linked to bill run 212b0102-ca9c-4b41-881b-f20e7721f2c9.
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -3134,53 +2852,48 @@ paths:
                   value:
                     statusCode: 422
                     error: Unprocessable Entity
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
-                      linked to regime wrls.
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
     delete:
       operationId: DeleteBillRunInvoice
-      description: Delete the specified invoice and all linked licences and transactions.
-        As part of the deletion the linked bill run will be updated.
+      description: Delete the specified invoice and all linked licences and transactions. As part of the deletion the linked bill run will be updated.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
-      - name: invoiceId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating an invoice.
-        schema:
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: invoiceId
+          in: path
+          required: true
           description: Internal ID (GUID) allocated by the CM when creating an invoice.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating an invoice.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '204':
+        "204":
           description: Success
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -3189,7 +2902,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -3204,7 +2917,7 @@ paths:
                     statusCode: 404
                     error: Not found
                     message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
-        '409':
+        "409":
           description: Failed - the action conflicts with something
           content:
             application/json:
@@ -3212,9 +2925,8 @@ paths:
                 example:
                   statusCode: 409
                   error: Conflict
-                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be
-                    edited because its status is billed.
-        '422':
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be edited because its status is billed.
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -3223,34 +2935,29 @@ paths:
                   value:
                     statusCode: 422
                     error: Unprocessable Entity
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
-                      linked to regime wrls.
-  "/v2/{regime}/calculate-charge":
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
+  /v2/{regime}/calculate-charge:
     post:
       operationId: CalculateCharge
-      description: Request to calculate a standalone charge based on a set of charge
-        parameters, without creating a transaction. Input and output data is not retained
-        in the CM.
+      description: Request to calculate a standalone charge based on a set of charge parameters, without creating a transaction. Input and output data is not retained in the CM.
       tags:
-      - calculate
+        - calculate
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -3261,8 +2968,7 @@ paths:
                     type: object
                     properties:
                       chargeValue:
-                        description: The value of the transaction in pence based on
-                          the response from the rules service
+                        description: The value of the transaction in pence based on the response from the rules service
                         type: number
                         example: 9290
                       sourceFactor:
@@ -3278,26 +2984,21 @@ paths:
                         type: number
                         example: 0.003
                       licenceHolderChargeAgreement:
-                        description: Summary of the Section 130 charge calculation
-                          in a specific format required by the transaction file
+                        description: Summary of the Section 130 charge calculation in a specific format required by the transaction file
                         type: string
                         nullable: true
                         example: S130U x 0.5
                       chargeElementAgreement:
-                        description: Summary of the Section 126 or Section 127 charge
-                          calculations in a specific format required by the transaction
-                          file
+                        description: Summary of the Section 126 or Section 127 charge calculations in a specific format required by the transaction file
                         type: string
                         nullable: true
                         example: S126 x 0.8
                       eiucSourceFactor:
-                        description: The EIUC adjusted source factor applied to the
-                          calculation
+                        description: The EIUC adjusted source factor applied to the calculation
                         type: number
                         example: 0.2
                       eiuc:
-                        description: Environmental Improvement Unit Charge (EIUC)
-                          for the transaction
+                        description: Environmental Improvement Unit Charge (EIUC) for the transaction
                         type: number
                         example: 0.2
                       suc:
@@ -3310,12 +3011,12 @@ paths:
                   sourceFactor: 3
                   seasonFactor: 1.6
                   lossFactor: 0.03
-                  licenceHolderChargeAgreement:
-                  chargeElementAgreement:
+                  licenceHolderChargeAgreement: null
+                  chargeElementAgreement: null
                   eiucSourceFactor: 0
                   eiuc: 0
                   suc: 1495
-        '400':
+        "400":
           description: Failed - issue with the Rules Service
           content:
             application/json:
@@ -3330,7 +3031,7 @@ paths:
                     statusCode: 400
                     error: Bad Request
                     message: 'Rules service error: [error message]'
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -3339,7 +3040,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '422':
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -3374,8 +3075,7 @@ paths:
                   type: string
                   example: 31-MAR-2019
                 credit:
-                  description: Boolean indicator to show whether the transaction is
-                    a credit (negative value)
+                  description: Boolean indicator to show whether the transaction is a credit (negative value)
                   type: boolean
                   example: false
                 billableDays:
@@ -3385,15 +3085,13 @@ paths:
                   maximum: 366
                   example: 149
                 authorisedDays:
-                  description: The number of days per year in which abstraction is
-                    authorised under the terms of the licence
+                  description: The number of days per year in which abstraction is authorised under the terms of the licence
                   type: integer
                   minimum: 0
                   maximum: 366
                   example: 214
                 volume:
-                  description: The volume (in thousands of cubic metres) on which
-                    the charge is based
+                  description: The volume (in thousands of cubic metres) on which the charge is based
                   type: number
                   minimum: 0
                   example: 19.909
@@ -3401,36 +3099,34 @@ paths:
                   description: Source on which standard charge calculation based
                   type: string
                   enum:
-                  - Supported
-                  - Kielder
-                  - Unsupported
-                  - Tidal
+                    - Supported
+                    - Kielder
+                    - Unsupported
+                    - Tidal
                   example: Unsupported
                 season:
                   description: Season on which charge calculation based
                   type: string
                   enum:
-                  - Summer
-                  - Winter
-                  - All Year
+                    - Summer
+                    - Winter
+                    - All Year
                   example: Summer
                 loss:
                   description: Loss on which charge calculation based
                   type: string
                   enum:
-                  - High
-                  - Medium
-                  - Low
-                  - Very Low
+                    - High
+                    - Medium
+                    - Low
+                    - Very Low
                   example: Medium
                 twoPartTariff:
-                  description: Boolean indicator to show whether the transaction is
-                    for the second part of a 2-part tariff charge
+                  description: Boolean indicator to show whether the transaction is for the second part of a 2-part tariff charge
                   type: boolean
                   example: true
                 compensationCharge:
-                  description: Boolean indicator to show whether the transaction relates
-                    to a compensation charge
+                  description: Boolean indicator to show whether the transaction relates to a compensation charge
                   type: boolean
                   example: false
                 eiucSource:
@@ -3438,65 +3134,60 @@ paths:
                   type: string
                   example: Tidal
                 waterUndertaker:
-                  description: Boolean indicator to show whether the transaction is
-                    for a water undertaker
+                  description: Boolean indicator to show whether the transaction is for a water undertaker
                   type: boolean
                   example: false
                 regionalChargingArea:
-                  description: The name of the region relevant to the determination
-                    of the SUC and / or EIUC value to be used in the calculation
+                  description: The name of the region relevant to the determination of the SUC and / or EIUC value to be used in the calculation
                   type: string
                   enum:
-                  - Anglian
-                  - Midlands
-                  - South West
-                  - North West
-                  - Southern
-                  - Thames
-                  - Northumbria
-                  - Yorkshire
-                  - Wales
+                    - Anglian
+                    - Midlands
+                    - South West
+                    - North West
+                    - Southern
+                    - Thames
+                    - Northumbria
+                    - Yorkshire
+                    - Wales
                   example: Northumbria
                 section126Factor:
-                  description: The factor to apply to the charge where a section 126
-                    charge agreement is relevant to the transaction
+                  description: The factor to apply to the charge where a section 126 charge agreement is relevant to the transaction
                   type: number
                   minimum: 0
                   maximum: 1
                   example: 0.75
                 section127Agreement:
-                  description: Indicator to show whether a section 127 charge agreement
-                    applies to the transaction
+                  description: Indicator to show whether a section 127 charge agreement applies to the transaction
                   type: boolean
                   example: false
                 section130Agreement:
-                  description: Indicator to show whether a section 130 charge agreement
-                    applies to the transaction
+                  description: Indicator to show whether a section 130 charge agreement applies to the transaction
                   type: boolean
                   example: true
               required:
-              - periodStart
-              - periodEnd
-              - billableDays
-              - authorisedDays
-              - volume
-              - source
-              - season
-              - loss
-              - section130Agreement
-              - section127Agreement
-              - twoPartTariff
-              - compensationCharge
-              - regionalChargingArea
-              - credit
-              - waterUndertaker
+                - periodStart
+                - periodEnd
+                - billableDays
+                - authorisedDays
+                - volume
+                - source
+                - season
+                - loss
+                - section130Agreement
+                - section127Agreement
+                - twoPartTariff
+                - compensationCharge
+                - regionalChargingArea
+                - credit
+                - waterUndertaker
             example:
               periodStart: 01-APR-2020
               periodEnd: 31-MAR-2021
               credit: false
               billableDays: 214
               authorisedDays: 214
-              volume: '3.5865'
+              volume: "3.5865"
               source: Supported
               season: Summer
               loss: Low
@@ -3508,7 +3199,7 @@ paths:
               section126Factor: 1
               section127Agreement: false
               section130Agreement: false
-  "/v2/{regime}/customer-changes":
+  /v2/{regime}/customer-changes:
     post:
       operationId: CreateCustomerChange
       description: |
@@ -3578,27 +3269,25 @@ paths:
         | 2  | `0000002` | Row index |
         | 3  | `3` | Row count |
       tags:
-      - customer
+        - customer
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
       responses:
-        '201':
+        "201":
           description: Success
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -3614,26 +3303,24 @@ paths:
               type: object
               properties:
                 region:
-                  description: A single-digit region identifier for a transaction
-                    or customer
+                  description: A single-digit region identifier for a transaction or customer
                   type: string
                   enum:
-                  - A
-                  - B
-                  - E
-                  - N
-                  - S
-                  - T
-                  - W
-                  - Y
+                    - A
+                    - B
+                    - E
+                    - "N"
+                    - S
+                    - T
+                    - W
+                    - "Y"
                   example: A
                 customerReference:
                   description: Customer Number of the invoicee
                   type: string
                   example: B19120000A
                 customerName:
-                  description: Name of the customer as it should be displayed on the
-                    invoice (or credit note)
+                  description: Name of the customer as it should be displayed on the invoice (or credit note)
                   type: string
                   maxLength: 240
                   example: Mr W Aston
@@ -3677,10 +3364,10 @@ paths:
                   nullable: true
                   example: SO74 3KD
               required:
-              - region
-              - customerReference
-              - customerName
-              - addressLine1
+                - region
+                - customerReference
+                - customerName
+                - addressLine1
             example:
               region: A
               customerReference: BB02BEEB
@@ -3688,43 +3375,38 @@ paths:
               addressLine1: 1 Monster Lane
               addressLine2: High Town
               addressLine4: Chigley
-  "/v2/{regime}/customer-files/{days}":
+  /v2/{regime}/customer-files/{days}:
     get:
       operationId: ListCustomerFiles
-      description: Request a list of 'customer files'. Each record contains the details
-        for a file of customer changes the API generated and sent to SSCL.
+      description: Request a list of 'customer files'. Each record contains the details for a file of customer changes the API generated and sent to SSCL.
       tags:
-      - customer
+        - customer
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: days
-        in: path
-        required: false
-        description: Number of days of customer files to retrieve, where 0 = files
-          generated today, 1 = files generated yesterday and today, etc.
-        schema:
-          description: Number of days of customer files to retrieve, where 0 = files
-            generated today, 1 = files generated yesterday and today, etc.
-          type: integer
-          minimum: 0
-          default: 30
-          example: 15
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: days
+          in: path
+          required: false
+          description: Number of days of customer files to retrieve, where 0 = files generated today, 1 = files generated yesterday and today, etc.
+          schema:
+            description: Number of days of customer files to retrieve, where 0 = files generated today, 1 = files generated yesterday and today, etc.
+            type: integer
+            minimum: 0
+            default: 30
+            example: 15
       responses:
-        '200':
+        "200":
           description: Success
           content:
             application/json:
@@ -3734,32 +3416,27 @@ paths:
                   type: object
                   properties:
                     id:
-                      description: Internal ID (GUID) allocated by the CM when creating
-                        a customer file
+                      description: Internal ID (GUID) allocated by the CM when creating a customer file
                       type: string
                       format: uuid
                       example: fd2ab097-3097-42bd-849e-046aa250a0d0
                     fileReference:
-                      description: A 10-digit reference indicating the name of the
-                        customer file generated by the CM for notifying SSCL of new
-                        / updated customer records
+                      description: A 10-digit reference indicating the name of the customer file generated by the CM for notifying SSCL of new / updated customer records
                       type: string
                       example: nalsc50004
                     status:
-                      description: Current status of the customer file. Note - if
-                        a file has a status of `pending` for more than a few minutes
-                        it is likely an issue as occurred during the generation
+                      description: Current status of the customer file. Note - if a file has a status of `pending` for more than a few minutes it is likely an issue as occurred during the generation
                       type: string
                       enum:
-                      - initialised
-                      - pending
-                      - exported
+                        - initialised
+                        - pending
+                        - exported
                       example: exported
                     exportedAt:
                       description: Date and time at which the customer file was generated
                       type: string
                       format: datetime
-                      example: '2020-09-11T11:56:41.578Z'
+                      example: "2020-09-11T11:56:41.578Z"
                     exportedCustomers:
                       type: array
                       items:
@@ -3767,77 +3444,70 @@ paths:
                         type: string
                         example: B19120000A
               example:
-              - id: 9523ff61-bd21-4800-aa7d-d97aa6c923aa
-                fileReference: nalac50001
-                status: exported
-                exportedAt: '2021-09-22T12:34:56.789Z'
-                exportedCustomers:
-                - AB01BEEB
-                - BB01BEEB
-                - CB01BEEB
-              - id: aa271bc5-0e36-4aeb-b636-64d95482825f
-                fileReference: nalac50002
-                status: exported
-                exportedAt: '2021-09-23T13:57:24.680Z'
-                exportedCustomers:
-                - DB02BEEB
-                - EB02BEEB
-                - FB02BEEB
-        '400':
+                - id: 9523ff61-bd21-4800-aa7d-d97aa6c923aa
+                  fileReference: nalac50001
+                  status: exported
+                  exportedAt: "2021-09-22T12:34:56.789Z"
+                  exportedCustomers:
+                    - AB01BEEB
+                    - BB01BEEB
+                    - CB01BEEB
+                - id: aa271bc5-0e36-4aeb-b636-64d95482825f
+                  fileReference: nalac50002
+                  status: exported
+                  exportedAt: "2021-09-23T13:57:24.680Z"
+                  exportedCustomers:
+                    - DB02BEEB
+                    - EB02BEEB
+                    - FB02BEEB
+        "400":
           description: Failed - issue with the request parameter
           content:
             application/json:
               example:
-                statusCode: '400,'
+                statusCode: 400,
                 error: Bad Request
                 message: Invalid request params input
-  "/v2/{regime}/bill-runs/{rebillBillRunId}/invoices/{rebillInvoiceId}/rebill":
+  /v2/{regime}/bill-runs/{rebillBillRunId}/invoices/{rebillInvoiceId}/rebill:
     patch:
       operationId: RebillBillRunInvoice
-      description: Request to rebill an invoice. Returns ID of the invoice that will
-        cancel out the original invoice, and the one to replace it.
+      description: Request to rebill an invoice. Returns ID of the invoice that will cancel out the original invoice, and the one to replace it.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: rebillBillRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-          When rebilling this represents the bill run you want to assign the new rebill
-          invoices to.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
-      - name: rebillInvoiceId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating an invoice.
-          When rebilling this represents the invoice you wish to rebill.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating an invoice.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: rebillBillRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run. When rebilling this represents the bill run you want to assign the new rebill invoices to.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: rebillInvoiceId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating an invoice. When rebilling this represents the invoice you wish to rebill.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating an invoice.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '201':
+        "201":
           description: Success
           content:
             application/json:
@@ -3850,30 +3520,25 @@ paths:
                       type: object
                       properties:
                         id:
-                          description: Internal ID (GUID) allocated by the CM when
-                            creating an invoice.
+                          description: Internal ID (GUID) allocated by the CM when creating an invoice.
                           type: string
                           format: uuid
                           example: fd2ab097-3097-42bd-849e-046aa250a0d0
                         rebilledType:
-                          description: The type of invoice in relation to rebilling.
-                            `O` (Original) means the invoice is not a result of rebilling.
-                            `C` (Cancel) is an invoice generated as a result of rebilling
-                            to 'cancel' the original invoice. `R` (Rebill) is the
-                            invoice generated to 'rebill' the original invoice.
+                          description: The type of invoice in relation to rebilling. `O` (Original) means the invoice is not a result of rebilling. `C` (Cancel) is an invoice generated as a result of rebilling to 'cancel' the original invoice. `R` (Rebill) is the invoice generated to 'rebill' the original invoice.
                           type: string
                           enum:
-                          - C
-                          - O
-                          - R
+                            - C
+                            - O
+                            - R
                           example: R
               example:
                 invoices:
-                - id: f62faabc-d65e-4242-a106-9777c1d57db7
-                  rebilledType: C
-                - id: db82bf38-638a-44d3-b1b3-1ae8524d9c38
-                  rebilledType: R
-        '403':
+                  - id: f62faabc-d65e-4242-a106-9777c1d57db7
+                    rebilledType: C
+                  - id: db82bf38-638a-44d3-b1b3-1ae8524d9c38
+                    rebilledType: R
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -3882,7 +3547,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -3897,7 +3562,7 @@ paths:
                     statusCode: 404
                     error: Not found
                     message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
-        '409':
+        "409":
           description: Failed - the invoice has already been rebilled
           content:
             application/json:
@@ -3906,28 +3571,23 @@ paths:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 has already
-                      been rebilled.
+                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 has already been rebilled.
                 Invoice already on bill run:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is already
-                      on bill run aa630ae0-0e51-4166-9025-66576c513f7f.
+                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is already on bill run aa630ae0-0e51-4166-9025-66576c513f7f.
                 Invoice on an unbilled bill run:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Bill run aa630ae0-0e51-4166-9025-66576c513f7f does not
-                      have a status of 'billed'.
+                    message: Bill run aa630ae0-0e51-4166-9025-66576c513f7f does not have a status of 'billed'.
                 Invoice is for a different region:
                   value:
                     statusCode: 409
                     error: Conflict
-                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is for
-                      region T but bill run aa630ae0-0e51-4166-9025-66576c513f7f is
-                      for region A.
-        '422':
+                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is for region T but bill run aa630ae0-0e51-4166-9025-66576c513f7f is for region A.
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -3936,58 +3596,49 @@ paths:
                   value:
                     statusCode: 422
                     error: Unprocessable Entity
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
-                      linked to regime wrls.
-  "/v2/{regime}/bill-runs/{billRunId}/licences/{licenceId}":
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
+  /v2/{regime}/bill-runs/{billRunId}/licences/{licenceId}:
     delete:
       operationId: DeleteBillRunLicence
-      description: Delete the specified licence and all linked transactions. The linked
-        bill run status will temporarily be set to `pending` during deletion and restored
-        to its original status when deletion is complete. As part of the deletion
-        the linked invoice and bill run will also be updated. If this results in the
-        linked invoice being empty then it will also be deleted. If _this_ results
-        in the bill run being empty then its status will be set to `initialised`.
+      description: Delete the specified licence and all linked transactions. The linked bill run status will temporarily be set to `pending` during deletion and restored to its original status when deletion is complete. As part of the deletion the linked invoice and bill run will also be updated. If this results in the linked invoice being empty then it will also be deleted. If _this_ results in the bill run being empty then its status will be set to `initialised`.
       tags:
-      - bill-run
+        - bill-run
       parameters:
-      - name: regime
-        in: path
-        required: true
-        description: Charging regime to use
-        schema:
-          description: Short reference for a regime, referred to as a 'slug'. This
-            is also what we expect to see in the path as the regime identifier when
-            making a request
-          type: string
-          enum:
-          - cfd
-          - pas
-          - wml
-          - wrls
-          example: wrls
-      - name: billRunId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a bill run.
-        schema:
-          description: Internal ID (GUID) allocated by the CM when creating a bill
-            run.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
-      - name: licenceId
-        in: path
-        required: true
-        description: Internal ID (GUID) allocated by the CM when creating a licence.
-        schema:
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: Short reference for a regime, referred to as a 'slug'. This is also what we expect to see in the path as the regime identifier when making a request
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: billRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: licenceId
+          in: path
+          required: true
           description: Internal ID (GUID) allocated by the CM when creating a licence.
-          type: string
-          format: uuid
-          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a licence.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
       responses:
-        '204':
+        "204":
           description: Success
-        '403':
+        "403":
           description: Failed - not authorised
           content:
             application/json:
@@ -3996,7 +3647,7 @@ paths:
                   statusCode: 403
                   error: Forbidden
                   message: Unauthorised for regime 'wrls'
-        '404':
+        "404":
           description: Failed - unknown ID
           content:
             application/json:
@@ -4011,7 +3662,7 @@ paths:
                     statusCode: 404
                     error: Not found
                     message: Licence 458d2739-6ae6-4919-ac12-5536589d3af9 is unknown.
-        '409':
+        "409":
           description: Failed - the action conflicts with something
           content:
             application/json:
@@ -4019,9 +3670,8 @@ paths:
                 example:
                   statusCode: 409
                   error: Conflict
-                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be
-                    edited because its status is billed.
-        '422':
+                  message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 cannot be edited because its status is billed.
+        "422":
           description: Failed - issue with the requested data
           content:
             application/json:
@@ -4030,19 +3680,14 @@ paths:
                   value:
                     statusCode: 422
                     error: Unprocessable Entity
-                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not
-                      linked to regime wrls.
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
 security:
-- OAuth2: []
+  - OAuth2: []
 components:
   securitySchemes:
     OAuth2:
       type: oauth2
-      description: The API uses [AWS Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/what-is-amazon-cognito.html)
-        to manage authentication and authorisation. To use it you will first need
-        a cognito client ID and password. You then use these to request a bearer token
-        from AWS Cognito. The bearer token is then sent in the `Authorisation` header
-        of your request
+      description: The API uses [AWS Cognito](https://docs.aws.amazon.com/cognito/latest/developerguide/what-is-amazon-cognito.html) to manage authentication and authorisation. To use it you will first need a cognito client ID and password. You then use these to request a bearer token from AWS Cognito. The bearer token is then sent in the `Authorisation` header of your request
       flows:
         clientCredentials:
           tokenUrl: https://chargingmoduleapi.auth.eu-west-1.amazoncognito.com/oauth2/token


### PR DESCRIPTION
We hadn't spotted that [Document list customer files endpoint](https://github.com/DEFRA/sroc-service-team/pull/102) had inadvertently duplicated the endpoint ID of the existing test endpoint.

This change fixes that and updates `draft.yml`.

**Note**

We have a number of alignment changes in `draft.yml` as well. This was because the JSON was converted to YAML using [yq](https://mikefarah.gitbook.io/yq/) instead of (https://www.json2yaml.com/) as the site was down at the time of making the change.

We don't mind. In fact, we think it does a better job! For reference yq was installed using `brew install yq` and the command to get yq to convert our json was `yq eval -P openapi/openapi.json > openapi/versions/draft.yml`.