### PR TITLE
Fix invalid value for customer files 'required'

### DIFF
--- a/openapi/schema/parameters.yml
+++ b/openapi/schema/parameters.yml
@@ -22,8 +22,7 @@ customerFileId:
 days:
   name: days
   in: path
-  required: false
-  description: "Number of days of customer files to retrieve, where 0 = files generated today, 1 = files generated yesterday and today, etc."
+  description: "OPTIONAL. Number of days of customer files to retrieve, where 0 = files generated today, 1 = files generated yesterday and today, etc. Defaults to 30 days if not provided"
   schema:
     $ref: 'fields.yml#/days'
 invoiceId:

--- a/openapi/versions/draft.yml
+++ b/openapi/versions/draft.yml
@@ -3397,8 +3397,7 @@ paths:
             example: wrls
         - name: days
           in: path
-          required: false
-          description: Number of days of customer files to retrieve, where 0 = files generated today, 1 = files generated yesterday and today, etc.
+          description: OPTIONAL. Number of days of customer files to retrieve, where 0 = files generated today, 1 = files generated yesterday and today, etc. Defaults to 30 days if not provided
           schema:
             description: Number of days of customer files to retrieve, where 0 = files generated today, 1 = files generated yesterday and today, etc.
             type: integer


### PR DESCRIPTION
In [Document list customer files endpoint](https://github.com/DEFRA/sroc-service-team/pull/102) we added details about our new customer file endpoint which includes an optional path parameter. Hapi is fine with this and in our opinion, it looks much cleaner. However, Swagger doesn't support optional path parameters

> In OpenAPI, a path parameter is defined using in: path. The parameter name must be the same as specified in the path. Also remember to add required: true, because path parameters are always required.
>
> https://swagger.io/docs/specification/describing-parameters/#path-parameters

So, `required: false` is an invalid attribute for a path param in Swagger and SwaggerHub highlights it as an error. The only workaround is to drop the required and document the fact it's optional ☹️