### PR TITLE
Remove draft notice from `v0-15-0.yml`

### DIFF
--- a/openapi/versions/v0-15-0.yml
+++ b/openapi/versions/v0-15-0.yml
@@ -1,8 +1,6 @@
 openapi: 3.0.0
 info:
   description: |
-    > This `draft` version represents the next release of the API.
-
     Provides an interface for calculating charges, creating and queuing transactions, and generating transaction and customer files used to produce Environment Agency invoices.
 
     ## Overview


### PR DESCRIPTION
When updating the docs for `v0.15.0` we inadvertently left the draft notice at the top of the file. This PR removes this.